### PR TITLE
feat: [DASHBOARD] remove

### DIFF
--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/dashboard/DashboardViewModel.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/dashboard/DashboardViewModel.kt
@@ -3,6 +3,9 @@ package io.github.openflocon.flocondesktop.features.dashboard
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.openflocon.domain.common.DispatcherProvider
+import io.github.openflocon.domain.dashboard.models.DashboardId
+import io.github.openflocon.domain.dashboard.usecase.DeleteCurrentDeviceSelectedDashboardUseCase
+import io.github.openflocon.domain.dashboard.usecase.DeleteDashboardUseCase
 import io.github.openflocon.domain.dashboard.usecase.ObserveCurrentDeviceDashboardUseCase
 import io.github.openflocon.domain.dashboard.usecase.SendCheckBoxUpdateDeviceDeviceUseCase
 import io.github.openflocon.domain.dashboard.usecase.SendClickEventToDeviceDeviceUseCase
@@ -30,6 +33,8 @@ class DashboardViewModel(
     private val dashboardSelectorDelegate: DashboardSelectorDelegate,
     private val dispatcherProvider: DispatcherProvider,
     private val feedbackDisplayer: FeedbackDisplayer,
+    private val deleteCurrentDeviceSelectedDashboardUseCase: DeleteCurrentDeviceSelectedDashboardUseCase,
+    private val deleteDashboardUseCase: DeleteDashboardUseCase,
 ) : ViewModel(dashboardSelectorDelegate) {
 
     val deviceDashboards: StateFlow<DashboardsStateUiModel> = dashboardSelectorDelegate.deviceDashboards
@@ -78,5 +83,19 @@ class DashboardViewModel(
 
     fun onDashboardSelected(selected: DeviceDashboardUiModel) {
         dashboardSelectorDelegate.onDashboardSelected(selected.id)
+    }
+
+    fun deleteCurrentDashboard() {
+        viewModelScope.launch(dispatcherProvider.viewModel) {
+            deleteCurrentDeviceSelectedDashboardUseCase()
+            feedbackDisplayer.displayMessage("Dashboard removed")
+        }
+    }
+
+    fun onDeleteClicked(dashboard: DeviceDashboardUiModel) {
+        viewModelScope.launch(dispatcherProvider.viewModel) {
+            deleteDashboardUseCase(dashboard.id)
+            feedbackDisplayer.displayMessage("Dashboard removed")
+        }
     }
 }

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/dashboard/view/DashboardScreen.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/dashboard/view/DashboardScreen.kt
@@ -1,9 +1,12 @@
 package io.github.openflocon.flocondesktop.features.dashboard.view
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -16,7 +19,9 @@ import io.github.openflocon.flocondesktop.features.dashboard.model.DashboardView
 import io.github.openflocon.flocondesktop.features.dashboard.model.DashboardsStateUiModel
 import io.github.openflocon.flocondesktop.features.dashboard.model.DeviceDashboardUiModel
 import io.github.openflocon.library.designsystem.FloconTheme
+import io.github.openflocon.library.designsystem.components.FloconDropdownMenuItem
 import io.github.openflocon.library.designsystem.components.FloconFeature
+import io.github.openflocon.library.designsystem.components.FloconOverflow
 import io.github.openflocon.library.designsystem.components.FloconPageTopBar
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -41,6 +46,8 @@ fun DashboardScreen(modifier: Modifier = Modifier) {
         submitTextField = viewModel::onTextFieldSubmit,
         submitForm = viewModel::onFormSubmit,
         onUpdateCheckBox = viewModel::onUpdateCheckBox,
+        deleteCurrentDashboard = viewModel::deleteCurrentDashboard,
+        onDeleteClicked = viewModel::onDeleteClicked,
     )
 }
 
@@ -49,6 +56,8 @@ fun DashboardScreen(
     state: DashboardViewState?,
     deviceDashboards: DashboardsStateUiModel,
     onDashboardSelected: (DeviceDashboardUiModel) -> Unit,
+    onDeleteClicked: (DeviceDashboardUiModel) -> Unit,
+    deleteCurrentDashboard: () -> Unit,
     onClickButton: (buttonId: String) -> Unit,
     submitTextField: (textFieldId: String, value: String) -> Unit,
     submitForm: (formId: String, formValues: Map<String, Any>) -> Unit,
@@ -65,7 +74,20 @@ fun DashboardScreen(
                     dashboardsState = deviceDashboards,
                     onDashboardSelected = onDashboardSelected,
                     modifier = Modifier.fillMaxWidth(),
+                    onDeleteClicked = onDeleteClicked,
                 )
+            },
+            filterBar = {
+                Box(modifier = Modifier.weight(1f)) // to have actions on the right
+            },
+            actions = {
+                FloconOverflow {
+                    FloconDropdownMenuItem(
+                        text = "Delete Dashboards",
+                        leadingIcon = Icons.Outlined.Delete,
+                        onClick = { deleteCurrentDashboard() }
+                    )
+                }
             }
         )
 

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/dashboard/view/DashboardSelectorView.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/dashboard/view/DashboardSelectorView.kt
@@ -1,14 +1,19 @@
 package io.github.openflocon.flocondesktop.features.dashboard.view
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import io.github.openflocon.flocondesktop.features.dashboard.model.DashboardsStateUiModel
@@ -36,6 +43,7 @@ import io.github.openflocon.library.designsystem.components.defaultPlaceHolder
 internal fun DashboardSelectorView(
     dashboardsState: DashboardsStateUiModel,
     onDashboardSelected: (DeviceDashboardUiModel) -> Unit,
+    onDeleteClicked: (DeviceDashboardUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -99,10 +107,29 @@ internal fun DashboardSelectorView(
 
                 filteredItems.fastForEach { dashboard ->
                     FloconDropdownMenuItem(
-                        text = dashboard.id, onClick = {
+                        text = dashboard.id,
+                        onClick = {
                             onDashboardSelected(dashboard)
                             expanded = false
-                        })
+                        },
+                        secondaryAction = {
+                            Box(
+                                Modifier.clip(RoundedCornerShape(4.dp))
+                                    .background(
+                                        Color.White.copy(alpha = 0.8f)
+                                    ).padding(2.dp).clickable {
+                                        onDeleteClicked(dashboard)
+                                    },
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                FloconIcon(
+                                    imageVector = Icons.Outlined.Close,
+                                    tint = FloconTheme.colorPalette.primary,
+                                    modifier = Modifier.size(14.dp)
+                                )
+                            }
+                        }
+                    )
                 }
             }
         }

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/dashboard/datasource/DashboardLocalDataSource.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/dashboard/datasource/DashboardLocalDataSource.kt
@@ -9,4 +9,8 @@ interface DashboardLocalDataSource {
     suspend fun saveDashboard(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel, dashboard: DashboardDomainModel)
     fun observeDashboard(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel, dashboardId: DashboardId): Flow<DashboardDomainModel?>
     fun observeDeviceDashboards(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel): Flow<List<DashboardId>>
+    suspend fun deleteDashboard(
+        deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,
+        dashboardId: DashboardId
+    )
 }

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/dashboard/datasource/DeviceDashboardsDataSource.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/dashboard/datasource/DeviceDashboardsDataSource.kt
@@ -13,4 +13,8 @@ interface DeviceDashboardsDataSource {
         dashboardId: DashboardId,
     )
 
+    fun deleteDashboard(
+        dashboardId: DashboardId,
+        deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel
+    )
 }

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/dashboard/repository/DashboardRepositoryImpl.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/dashboard/repository/DashboardRepositoryImpl.kt
@@ -54,8 +54,7 @@ class DashboardRepositoryImpl(
         dashboardLocalDataSource.observeDashboard(
             deviceIdAndPackageName = deviceIdAndPackageName,
             dashboardId = dashboardId,
-        )
-            .flowOn(dispatcherProvider.data)
+        ).flowOn(dispatcherProvider.data)
 
     override suspend fun sendClickEvent(
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,
@@ -130,10 +129,26 @@ class DashboardRepositoryImpl(
     override fun observeSelectedDeviceDashboard(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel): Flow<DashboardId?> =
         deviceDashboardsDataSource.observeSelectedDeviceDashboard(
             deviceIdAndPackageName = deviceIdAndPackageName,
-        )
+        ).flowOn(dispatcherProvider.data)
 
     override fun observeDeviceDashboards(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel): Flow<List<DashboardId>> =
         dashboardLocalDataSource.observeDeviceDashboards(
             deviceIdAndPackageName = deviceIdAndPackageName,
-        )
+        ).flowOn(dispatcherProvider.data)
+
+    override suspend fun deleteDashboard(
+        deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,
+        dashboardId: DashboardId
+    ) {
+        withContext(dispatcherProvider.data) {
+            dashboardLocalDataSource.deleteDashboard(
+                deviceIdAndPackageName = deviceIdAndPackageName,
+                dashboardId = dashboardId,
+            )
+            deviceDashboardsDataSource.deleteDashboard(
+                deviceIdAndPackageName = deviceIdAndPackageName,
+                dashboardId = dashboardId,
+            )
+        }
+    }
 }

--- a/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/dashboard/dao/FloconDashboardDao.kt
+++ b/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/dashboard/dao/FloconDashboardDao.kt
@@ -11,6 +11,8 @@ import io.github.openflocon.data.local.dashboard.models.DashboardEntity
 import io.github.openflocon.data.local.dashboard.models.DashboardContainerEntity
 import io.github.openflocon.data.local.dashboard.models.DashboardWithContainersAndElements
 import io.github.openflocon.domain.dashboard.models.DashboardDomainModel
+import io.github.openflocon.domain.dashboard.models.DashboardId
+import io.github.openflocon.domain.device.models.AppPackageName
 import io.github.openflocon.domain.device.models.DeviceId
 import kotlinx.coroutines.flow.Flow
 
@@ -110,4 +112,17 @@ interface FloconDashboardDao {
             insertDashboardElements(allElementsToInsert)
         }
     }
+
+    @Query(
+        """
+        DELETE FROM DashboardEntity 
+        WHERE deviceId = :deviceId AND dashboardId = :dashboardId
+        AND packageName = :packageName
+        """,
+    )
+    suspend fun deleteDashboard(
+        deviceId: String,
+        packageName: String,
+        dashboardId: String,
+    )
 }

--- a/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/dashboard/datasource/DashboardLocalDataSourceRoom.kt
+++ b/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/dashboard/datasource/DashboardLocalDataSourceRoom.kt
@@ -15,17 +15,14 @@ import kotlinx.coroutines.withContext
 
 class DashboardLocalDataSourceRoom(
     private val dashboardDao: FloconDashboardDao,
-    private val dispatcherProvider: DispatcherProvider,
 ) : DashboardLocalDataSource {
 
     override suspend fun saveDashboard(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel, dashboard: DashboardDomainModel) {
-        withContext(dispatcherProvider.data) {
             dashboardDao.saveFullDashboard(
                 deviceId = deviceIdAndPackageName.deviceId,
                 packageName = deviceIdAndPackageName.packageName,
                 dashboard = dashboard,
             )
-        }
     }
 
     override fun observeDashboard(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel, dashboardId: DashboardId): Flow<DashboardDomainModel?> =
@@ -36,12 +33,21 @@ class DashboardLocalDataSourceRoom(
         )
             .map { it?.toDomain() }
             .distinctUntilChanged()
-            .flowOn(dispatcherProvider.data)
 
     override fun observeDeviceDashboards(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel): Flow<List<DashboardId>> =
         dashboardDao.observeDeviceDashboards(
             deviceId = deviceIdAndPackageName.deviceId,
             packageName = deviceIdAndPackageName.packageName,
         )
-            .flowOn(dispatcherProvider.data)
+
+    override suspend fun deleteDashboard(
+        deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,
+        dashboardId: DashboardId
+    ) {
+        dashboardDao.deleteDashboard(
+            deviceId = deviceIdAndPackageName.deviceId,
+            packageName = deviceIdAndPackageName.packageName,
+            dashboardId = dashboardId,
+        )
+    }
 }

--- a/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/dashboard/datasource/DeviceDashboardsDataSourceInMemory.kt
+++ b/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/dashboard/datasource/DeviceDashboardsDataSourceInMemory.kt
@@ -23,4 +23,12 @@ class DeviceDashboardsDataSourceInMemory : DeviceDashboardsDataSource {
         }
     }
 
+    override fun deleteDashboard(dashboardId: DashboardId, deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel) {
+        selectedDeviceDashboards.update {
+            if(it[deviceIdAndPackageName] == dashboardId) {
+                it - deviceIdAndPackageName
+            } else it
+        }
+    }
+
 }

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/dashboard/DI.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/dashboard/DI.kt
@@ -1,5 +1,7 @@
 package io.github.openflocon.domain.dashboard
 
+import io.github.openflocon.domain.dashboard.usecase.DeleteCurrentDeviceSelectedDashboardUseCase
+import io.github.openflocon.domain.dashboard.usecase.DeleteDashboardUseCase
 import io.github.openflocon.domain.dashboard.usecase.GetCurrentDeviceSelectedDashboardUseCase
 import io.github.openflocon.domain.dashboard.usecase.ObserveCurrentDeviceDashboardUseCase
 import io.github.openflocon.domain.dashboard.usecase.ObserveCurrentDeviceSelectedDashboardUseCase
@@ -23,4 +25,7 @@ internal val dashboardModule = module {
     factoryOf(::ObserveCurrentDeviceSelectedDashboardUseCase)
     factoryOf(::ObserveDeviceDashboardsUseCase)
     factoryOf(::SelectCurrentDeviceDashboardUseCase)
+
+    factoryOf(::DeleteDashboardUseCase)
+    factoryOf(::DeleteCurrentDeviceSelectedDashboardUseCase)
 }

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/dashboard/repository/DashboardRepository.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/dashboard/repository/DashboardRepository.kt
@@ -38,4 +38,9 @@ interface DashboardRepository {
         checkBoxId: String,
         value: Boolean,
     )
+
+    suspend fun deleteDashboard(
+        deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,
+        dashboardId: DashboardId
+    )
 }

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/dashboard/usecase/DeleteCurrentDeviceSelectedDashboardUseCase.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/dashboard/usecase/DeleteCurrentDeviceSelectedDashboardUseCase.kt
@@ -1,0 +1,12 @@
+package io.github.openflocon.domain.dashboard.usecase
+
+class DeleteCurrentDeviceSelectedDashboardUseCase(
+    private val deleteDashboardUseCase: DeleteDashboardUseCase,
+    private val getCurrentDeviceSelectedDashboardUseCase: GetCurrentDeviceSelectedDashboardUseCase,
+) {
+    suspend operator fun invoke() {
+        getCurrentDeviceSelectedDashboardUseCase()?.let {
+            deleteDashboardUseCase(it)
+        }
+    }
+}

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/dashboard/usecase/DeleteDashboardUseCase.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/dashboard/usecase/DeleteDashboardUseCase.kt
@@ -1,0 +1,19 @@
+package io.github.openflocon.domain.dashboard.usecase
+
+import io.github.openflocon.domain.dashboard.models.DashboardId
+import io.github.openflocon.domain.dashboard.repository.DashboardRepository
+import io.github.openflocon.domain.device.usecase.GetCurrentDeviceIdAndPackageNameUseCase
+
+class DeleteDashboardUseCase(
+    private val dashboardRepository: DashboardRepository,
+    private val getCurrentDeviceIdAndPackageNameUseCase: GetCurrentDeviceIdAndPackageNameUseCase,
+) {
+    suspend operator fun invoke(dashboardId: DashboardId) {
+        getCurrentDeviceIdAndPackageNameUseCase()?.let { current ->
+            dashboardRepository.deleteDashboard(
+                dashboardId = dashboardId,
+                deviceIdAndPackageName = current
+            )
+        }
+    }
+}

--- a/FloconDesktop/library/designsystem/src/commonMain/kotlin/io/github/openflocon/library/designsystem/components/FloconDropdown.kt
+++ b/FloconDesktop/library/designsystem/src/commonMain/kotlin/io/github/openflocon/library/designsystem/components/FloconDropdown.kt
@@ -68,11 +68,13 @@ fun FloconDropdownMenu(
 fun FloconDropdownMenuItem(
     text: String,
     onClick: () -> Unit,
+    secondaryAction: (@Composable () -> Unit)? = null,
     leadingIcon: ImageVector? = null
 ) {
     FloconMenuItem(
         text = text,
         onClick = onClick,
+        secondaryAction = secondaryAction,
         leadingIcon = leadingIcon
     )
 }

--- a/FloconDesktop/library/designsystem/src/commonMain/kotlin/io/github/openflocon/library/designsystem/components/FloconMenuItem.kt
+++ b/FloconDesktop/library/designsystem/src/commonMain/kotlin/io/github/openflocon/library/designsystem/components/FloconMenuItem.kt
@@ -33,6 +33,7 @@ fun FloconMenuItem(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    secondaryAction: (@Composable () -> Unit)? = null,
     leadingIcon: ImageVector? = null,
     trailingIcon: ImageVector? = null
 ) {
@@ -55,6 +56,7 @@ fun FloconMenuItem(
             style = FloconTheme.typography.labelMedium,
             modifier = Modifier.weight(1f)
         )
+        secondaryAction?.invoke()
         trailingIcon?.let { FloconMenuIcon(trailingIcon) }
     }
 }


### PR DESCRIPTION
https://github.com/openflocon/Flocon/issues/97

added an overflow menu with "Delete Dashboard" action

<img width="1038" height="189" alt="Screenshot 2025-09-16 at 19 51 58" src="https://github.com/user-attachments/assets/dda486be-af2a-4c81-82d0-c378534c98fb" />

And also added a possibility to remove them from the selector 


<img width="372" height="191" alt="Screenshot 2025-09-16 at 19 51 55" src="https://github.com/user-attachments/assets/fc63c4ea-5cd2-46e9-a211-0487df1ba403" />
