### PR TITLE
feat: [NETWORK] extract persisted query

### DIFF
--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/graphql/model/GraphQlExtracted.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/graphql/model/GraphQlExtracted.kt
@@ -1,11 +1,14 @@
 package io.github.openflocon.data.core.network.graphql.model
 
-data class GraphQlExtracted(
-    val request: Request,
-) {
-    data class Request(
+sealed interface GraphQlExtracted {
+    data class WithBody(
         val requestBody: GraphQlRequestBody,
         val queryName: String?,
         val operationType: String,
-    )
+    ) : GraphQlExtracted
+
+    data class PersistedQuery(
+        val queryName: String,
+        val operationType: String,
+    ) : GraphQlExtracted
 }

--- a/FloconDesktop/data/remote/src/commonTest/kotlin/com/flocon/data/remote/network/mapper/MapperTest.kt
+++ b/FloconDesktop/data/remote/src/commonTest/kotlin/com/flocon/data/remote/network/mapper/MapperTest.kt
@@ -1,0 +1,60 @@
+package com.flocon.data.remote.network.mapper
+
+import com.flocon.data.remote.network.models.FloconNetworkRequestDataModel
+import io.github.openflocon.data.core.network.graphql.model.GraphQlExtracted
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class MapperTest {
+
+    @Test
+    fun `should extract from body`() {
+        val decoded = FloconNetworkRequestDataModel(
+            url = "https://ourapi.com/graphql",
+            requestBody = """
+                {
+                  "query": "query UserData { user { id name } }",
+                  "variables": {}
+                }
+            """.trimIndent()
+        )
+
+        val result: GraphQlExtracted? = extractGraphQl(decoded)
+
+        assertNotNull(result)
+        assertIs<GraphQlExtracted.WithBody>(result)
+        assertEquals("UserData", result.queryName)
+        assertEquals("query", result.operationType)
+    }
+
+    @Test
+    fun `should extract from url with persisted query`() {
+        val decoded = FloconNetworkRequestDataModel(
+            url = "https://ourapi.com/graphql?operationName=UserData&variables=%7B%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22abcdef%22%7D%7D",
+            requestBody = null
+        )
+
+        val result = extractGraphQl(decoded)
+
+        assertNotNull(result)
+        assertIs<GraphQlExtracted.PersistedQuery>(result)
+        assertEquals("UserData", result.queryName)
+        assertEquals("persistedQuery", result.operationType)
+    }
+
+    @Test
+    fun `should return null for invalid request`() {
+        val decoded = FloconNetworkRequestDataModel(
+            url = "https://ourapi.com/graphql",
+            requestBody = "{ invalid json"
+        )
+
+        val result = extractGraphQl(decoded)
+
+        assertNull(result)
+    }
+
+}


### PR DESCRIPTION
fixes : https://github.com/openflocon/Flocon/issues/255

extracts queryName from graphQl persisted queries : `https://ourapi.com/graphql?operationName=UserData&variables=%7B%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%...`
