### PR TITLE
fix: [ANALYTICS] analytics detail panel

### DIFF
--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/mapper/Mapper.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/mapper/Mapper.kt
@@ -3,11 +3,14 @@ package io.github.openflocon.flocondesktop.features.analytics.mapper
 import io.github.openflocon.domain.analytics.models.AnalyticsItemDomainModel
 import io.github.openflocon.domain.common.time.formatTimestamp
 import io.github.openflocon.domain.device.models.DeviceIdAndPackageNameDomainModel
+import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsDetailUiModel
 import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsRowUiModel
 
 internal const val MAX_PROPERTIES_TO_SHOW = 7
 
-internal fun AnalyticsItemDomainModel.mapToUi(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel?): AnalyticsRowUiModel = AnalyticsRowUiModel(
+internal fun AnalyticsItemDomainModel.mapToUi(
+    deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel?
+): AnalyticsRowUiModel = AnalyticsRowUiModel(
     id = itemId,
     dateFormatted = formatTimestamp(createdAt),
     eventName = eventName,
@@ -18,5 +21,21 @@ internal fun AnalyticsItemDomainModel.mapToUi(deviceIdAndPackageName: DeviceIdAn
         )
     }.take(MAX_PROPERTIES_TO_SHOW),
     hasMoreProperties = properties.size > MAX_PROPERTIES_TO_SHOW,
+    isFromOldAppInstance = deviceIdAndPackageName?.appInstance?.let { it != this.appInstance } ?: false
+)
+
+
+internal fun AnalyticsItemDomainModel.mapToDetailUi(
+    deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel?
+): AnalyticsDetailUiModel = AnalyticsDetailUiModel(
+    id = itemId,
+    dateFormatted = formatTimestamp(createdAt),
+    eventName = eventName,
+    properties = properties.map {
+        AnalyticsDetailUiModel.PropertyUiModel(
+            name = it.name,
+            value = it.value,
+        )
+    },
     isFromOldAppInstance = deviceIdAndPackageName?.appInstance?.let { it != this.appInstance } ?: false
 )

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/model/AnalyticsDetailUiModel.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/model/AnalyticsDetailUiModel.kt
@@ -1,0 +1,28 @@
+package io.github.openflocon.flocondesktop.features.analytics.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class AnalyticsDetailUiModel(
+    val id: String,
+    val dateFormatted: String,
+    val eventName: String,
+    val properties: List<PropertyUiModel>,
+    val isFromOldAppInstance: Boolean,
+) {
+    @Immutable
+    data class PropertyUiModel(
+        val name: String,
+        val value: String,
+    )
+}
+
+fun previewAnalyticsDetailUiModel(isFromOldAppInstance: Boolean = false) = AnalyticsDetailUiModel(
+    id = "id",
+    dateFormatted = "2023-01-01 00:00:00",
+    eventName = "event_name",
+    properties = List(5) {
+        AnalyticsDetailUiModel.PropertyUiModel("param$it", "value$it")
+    },
+    isFromOldAppInstance = isFromOldAppInstance,
+)

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/view/AnalyticsDetailView.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/view/AnalyticsDetailView.kt
@@ -2,6 +2,7 @@ package io.github.openflocon.flocondesktop.features.analytics.view
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -28,6 +29,8 @@ import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsDeta
 import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsRowUiModel
 import io.github.openflocon.library.designsystem.FloconTheme
 import io.github.openflocon.library.designsystem.components.FloconHorizontalDivider
+import io.github.openflocon.library.designsystem.components.FloconVerticalScrollbar
+import io.github.openflocon.library.designsystem.components.rememberFloconScrollbarAdapter
 
 @Composable
 fun AnalyticsDetailView(
@@ -36,57 +39,67 @@ fun AnalyticsDetailView(
 ) {
     val scrollState = rememberScrollState()
     val linesLabelWidth: Dp = 130.dp
+    val scrollAdapter = rememberFloconScrollbarAdapter(scrollState)
 
-    SelectionContainer(
+    Box(
         modifier
             .background(FloconTheme.colorPalette.primary)
-            .verticalScroll(scrollState)
-            .padding(all = 18.dp),
     ) {
-        Column(
-            modifier = Modifier.fillMaxSize(),
+        SelectionContainer(
+            modifier = Modifier.fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(all = 18.dp),
         ) {
-            AnalyticsDetailLineTextView(
-                modifier = Modifier.fillMaxWidth(),
-                label = "Name",
-                value = state.eventName,
-                labelWidth = linesLabelWidth,
-                withDivider = false,
-            )
-            AnalyticsDetailLineTextView(
-                modifier = Modifier.fillMaxWidth(),
-                label = "Time",
-                value = state.dateFormatted,
-                labelWidth = linesLabelWidth,
-                withDivider = false,
-            )
-
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .border(
-                        width = 1.dp,
-                        color = FloconTheme.colorPalette.secondary,
-                        shape = FloconTheme.shapes.medium
-                    )
+                modifier = Modifier.fillMaxSize(),
             ) {
-                state.properties.forEachIndexed { index, property ->
-                    AnalyticsDetailLineTextView(
-                        modifier = Modifier.fillMaxWidth(),
-                        label = property.name,
-                        value = property.value,
-                        labelWidth = linesLabelWidth,
-                        withDivider = true,
-                    )
-                    if (index != state.properties.lastIndex) {
-                        FloconHorizontalDivider(
-                            modifier = Modifier.fillMaxWidth(),
-                            color = FloconTheme.colorPalette.secondary
+                AnalyticsDetailLineTextView(
+                    modifier = Modifier.fillMaxWidth(),
+                    label = "Name",
+                    value = state.eventName,
+                    labelWidth = linesLabelWidth,
+                    withDivider = false,
+                )
+                AnalyticsDetailLineTextView(
+                    modifier = Modifier.fillMaxWidth(),
+                    label = "Time",
+                    value = state.dateFormatted,
+                    labelWidth = linesLabelWidth,
+                    withDivider = false,
+                )
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = FloconTheme.colorPalette.secondary,
+                            shape = FloconTheme.shapes.medium
                         )
+                ) {
+                    state.properties.forEachIndexed { index, property ->
+                        AnalyticsDetailLineTextView(
+                            modifier = Modifier.fillMaxWidth(),
+                            label = property.name,
+                            value = property.value,
+                            labelWidth = linesLabelWidth,
+                            withDivider = true,
+                        )
+                        if (index != state.properties.lastIndex) {
+                            FloconHorizontalDivider(
+                                modifier = Modifier.fillMaxWidth(),
+                                color = FloconTheme.colorPalette.secondary
+                            )
+                        }
                     }
                 }
             }
         }
+        FloconVerticalScrollbar(
+            adapter = scrollAdapter,
+            modifier = Modifier.fillMaxHeight()
+                .align(Alignment.TopEnd)
+        )
     }
 }
 

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/view/AnalyticsDetailView.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/view/AnalyticsDetailView.kt
@@ -24,13 +24,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsDetailUiModel
 import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsRowUiModel
 import io.github.openflocon.library.designsystem.FloconTheme
 import io.github.openflocon.library.designsystem.components.FloconHorizontalDivider
 
 @Composable
 fun AnalyticsDetailView(
-    state: AnalyticsRowUiModel,
+    state: AnalyticsDetailUiModel,
     modifier: Modifier = Modifier
 ) {
     val scrollState = rememberScrollState()

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/view/AnalyticsScreen.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/analytics/view/AnalyticsScreen.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.openflocon.flocondesktop.features.analytics.AnalyticsViewModel
 import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsAction
 import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsContentStateUiModel
+import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsDetailUiModel
 import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsRowUiModel
 import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsScreenUiState
 import io.github.openflocon.flocondesktop.features.analytics.model.AnalyticsStateUiModel
@@ -91,7 +92,7 @@ fun AnalyticsScreen(
     onAnalyticsSelected: (DeviceAnalyticsUiModel) -> Unit,
     content: AnalyticsContentStateUiModel,
     onResetClicked: () -> Unit,
-    selectedItem: AnalyticsRowUiModel?,
+    selectedItem: AnalyticsDetailUiModel?,
     onAction: (AnalyticsAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/analytics/datasource/AnalyticsLocalDataSource.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/analytics/datasource/AnalyticsLocalDataSource.kt
@@ -11,6 +11,7 @@ interface AnalyticsLocalDataSource {
     fun observe(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel, analyticsTableId: AnalyticsTableId): Flow<List<AnalyticsItemDomainModel>>
     fun observeDeviceAnalytics(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel): Flow<List<AnalyticsIdentifierDomainModel>>
     suspend fun getDeviceAnalytics(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel): List<AnalyticsIdentifierDomainModel>
+    fun observeById(id: String, deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel) : Flow<AnalyticsItemDomainModel?>
 
     suspend fun delete(
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/analytics/repository/AnalyticsRepositoryImpl.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/analytics/repository/AnalyticsRepositoryImpl.kt
@@ -57,8 +57,17 @@ class AnalyticsRepositoryImpl(
     ): Flow<List<AnalyticsItemDomainModel>> = analyticsLocalDataSource.observe(
         deviceIdAndPackageName = deviceIdAndPackageName,
         analyticsTableId = analyticsTableId,
-    )
-        .flowOn(dispatcherProvider.data)
+    ).flowOn(dispatcherProvider.data)
+
+    override fun observeAnalyticsById(
+        id: String,
+        deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel
+    ): Flow<AnalyticsItemDomainModel?> {
+        return analyticsLocalDataSource.observeById(
+            id = id,
+            deviceIdAndPackageName = deviceIdAndPackageName,
+        ).flowOn(dispatcherProvider.data)
+    }
 
     override suspend fun deleteAnalytics(
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,

--- a/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/analytics/dao/FloconAnalyticsDao.kt
+++ b/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/analytics/dao/FloconAnalyticsDao.kt
@@ -25,16 +25,16 @@ interface FloconAnalyticsDao {
         SELECT * 
         FROM AnalyticsItemEntity 
         WHERE deviceId = :deviceId
-        AND analyticsTableId = :analyticsTableId 
+        AND itemId = :analyticsItemId 
         AND packageName = :packageName
         LIMIT 1
     """,
     )
-    fun observeAnalytics(
-        deviceId: DeviceId,
+    fun observeAnalyticsItemById(
+        deviceId: String,
         packageName: String,
-        analyticsTableId: String,
-    ): Flow<AnalyticsItemEntity?>
+        analyticsItemId: String,
+    ) : Flow<AnalyticsItemEntity?>
 
     @Query(
         """

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/analytics/DI.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/analytics/DI.kt
@@ -2,6 +2,7 @@ package io.github.openflocon.domain.analytics
 
 import io.github.openflocon.domain.analytics.usecase.ExportAnalyticsToCsvUseCase
 import io.github.openflocon.domain.analytics.usecase.GetCurrentDeviceSelectedAnalyticsUseCase
+import io.github.openflocon.domain.analytics.usecase.ObserveAnalyticsByIdUseCase
 import io.github.openflocon.domain.analytics.usecase.ObserveCurrentDeviceAnalyticsContentUseCase
 import io.github.openflocon.domain.analytics.usecase.ObserveCurrentDeviceSelectedAnalyticsUseCase
 import io.github.openflocon.domain.analytics.usecase.ObserveDeviceAnalyticsUseCase
@@ -24,4 +25,5 @@ internal val analyticsModule = module {
     factoryOf(::RemoveAnalyticsItemsBeforeUseCase)
     factoryOf(::RemoveOldSessionsAnalyticsUseCase)
     factoryOf(::ExportAnalyticsToCsvUseCase)
+    factoryOf(::ObserveAnalyticsByIdUseCase)
 }

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/analytics/repository/AnalyticsRepository.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/analytics/repository/AnalyticsRepository.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 interface AnalyticsRepository {
     fun observeAnalytics(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel, analyticsTableId: AnalyticsTableId): Flow<List<AnalyticsItemDomainModel>>
     suspend fun deleteAnalytics(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel, analyticsId: AnalyticsIdentifierDomainModel)
+    fun observeAnalyticsById(id: String, deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel): Flow<AnalyticsItemDomainModel?>
 
     suspend fun selectDeviceAnalytics(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel, analyticsTableId: AnalyticsTableId)
     fun observeSelectedDeviceAnalytics(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel): Flow<AnalyticsIdentifierDomainModel?>

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/analytics/usecase/ObserveAnalyticsByIdUseCase.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/analytics/usecase/ObserveAnalyticsByIdUseCase.kt
@@ -1,0 +1,28 @@
+package io.github.openflocon.domain.analytics.usecase
+
+import io.github.openflocon.domain.analytics.models.AnalyticsItemDomainModel
+import io.github.openflocon.domain.analytics.repository.AnalyticsRepository
+import io.github.openflocon.domain.device.usecase.ObserveCurrentDeviceIdAndPackageNameUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+
+class ObserveAnalyticsByIdUseCase(
+    private val observeCurrentDeviceIdAndPackageNameUseCase: ObserveCurrentDeviceIdAndPackageNameUseCase,
+    private val analyticsRepository: AnalyticsRepository,
+) {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    operator fun invoke(id: String): Flow<AnalyticsItemDomainModel?> =
+        observeCurrentDeviceIdAndPackageNameUseCase()
+            .flatMapLatest { deviceIdAndPackageName ->
+                if (deviceIdAndPackageName == null) {
+                    flowOf(null)
+                } else {
+                    analyticsRepository.observeAnalyticsById(
+                        deviceIdAndPackageName = deviceIdAndPackageName,
+                        id = id,
+                    )
+                }
+            }
+}


### PR DESCRIPTION
fixes : https://github.com/openflocon/Flocon/issues/296

When inspecting analytics events in the Flocon desktop app (MacOS), only 7 properties are displayed in the right sidebar properties panel. However, if I export the same events to CSV, all properties are present in the file.

Steps to Reproduce

Notice that only 7 properties appear in the right-hand pane.
Export the events as CSV and compare — all properties are included in the export.
Expected Behavior:

All analytics event properties should be visible in the MacOS desktop UI, not just the first 7.