### PR TITLE
refact: [CI] bump actions versions

### DIFF
--- a/.github/workflows/android_pr_check.yml
+++ b/.github/workflows/android_pr_check.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 21
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build with Gradle
         working-directory: FloconAndroid

--- a/.github/workflows/desktop_pr_check.yml
+++ b/.github/workflows/desktop_pr_check.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build with Gradle
         working-directory: FloconDesktop

--- a/.github/workflows/publish_android.yml
+++ b/.github/workflows/publish_android.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up temurin JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
github actions are using old versions :

[actions/checkout](https://github.com/actions/checkout/releases/tag/v6.0.1) is at v6
[actions/setup-java](https://github.com/actions/setup-java/releases/tag/v5.0.0) is at v5
[gradle/actions/setup-gradle](https://github.com/gradle/actions/releases/tag/v5.0.0) is at v5
