### PR TITLE
Bugfix: Logging condition is invalid in FloconKtorPlugin

### DIFF
--- a/FloconAndroid/ktor-interceptor/src/commonMain/kotlin/io/github/openflocon/flocon/ktor/FloconKtorPlugin.kt
+++ b/FloconAndroid/ktor-interceptor/src/commonMain/kotlin/io/github/openflocon/flocon/ktor/FloconKtorPlugin.kt
@@ -49,7 +49,7 @@ val FloconKtorPlugin = createClientPlugin("FloconKtorPlugin", ::FloconKtorPlugin
         val floconNetworkPlugin = FloconApp.instance?.client?.networkPlugin
         val request: HttpRequestBuilder = context
 
-        if (floconNetworkPlugin == null || shouldLogCallback(request)) {
+        if (floconNetworkPlugin == null || !shouldLogCallback(request)) {
             request.attributes.put(FLOCON_SHOULD_LOG, false)
             proceed()
             return@intercept


### PR DESCRIPTION
Currently network log is broken for `Ktor` users

There is a condition that is doing the opposite that it should