### PR TITLE
Windows: Enable menu and set upgrade UUID

### DIFF
--- a/FloconDesktop/composeApp/build.gradle.kts
+++ b/FloconDesktop/composeApp/build.gradle.kts
@@ -131,6 +131,8 @@ compose.desktop {
             }
             windows {
                 iconFile.set(project.file("src/desktopMain/resources/files/flocon_big.ico"))
+                menu = true
+                upgradeUuid = "5c6d2b4c-360a-4135-a445-68bfa25ce450"
             }
         }
     }


### PR DESCRIPTION
This will make the app show up as a start menu entry, so it can be started without having to navigate to the installation folder.

The upgrade UUID makes sure the current installation can be updated (see https://kotlinlang.org/docs/multiplatform/compose-native-distribution.html#macos-specific-configuration).