### PR TITLE
Improve network detail json text size and expand icon

### DIFF
--- a/FloconDesktop/library/designsystem/src/commonMain/kotlin/io/github/openflocon/library/designsystem/components/FloconJsonTree.kt
+++ b/FloconDesktop/library/designsystem/src/commonMain/kotlin/io/github/openflocon/library/designsystem/components/FloconJsonTree.kt
@@ -3,20 +3,23 @@ package io.github.openflocon.library.designsystem.components
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ChevronLeft
+import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
 import com.sebastianneubauer.jsontree.JsonTree
 import com.sebastianneubauer.jsontree.TreeState
 import com.sebastianneubauer.jsontree.defaultDarkColors
 import com.sebastianneubauer.jsontree.search.SearchState
 import com.sebastianneubauer.jsontree.search.rememberSearchState
+import io.github.openflocon.library.designsystem.FloconTheme
 
 @Composable
 fun FloconJsonTree(
     json: String,
     modifier: Modifier = Modifier,
     initialState: TreeState = TreeState.FIRST_ITEM_EXPANDED,
+    textStyle: TextStyle = FloconTheme.typography.bodyMedium,
     onError: (Throwable) -> Unit = {},
     searchState: SearchState = rememberSearchState()
 ) {
@@ -27,9 +30,10 @@ fun FloconJsonTree(
                 FloconCircularProgressIndicator() // TODO Better?
             },
             initialState = initialState,
-            icon = Icons.Outlined.ChevronLeft,
+            icon = Icons.Outlined.ChevronRight,
             searchState = searchState,
             colors = defaultDarkColors,
+            textStyle = textStyle,
             onError = onError,
             modifier = Modifier.fillMaxSize()
         )


### PR DESCRIPTION
The text size which is currently used for JsonTree in the network detail screen and json screen feels a little bit too big. I decreased the text size by using one of Flocons TextStyles, which improves readability especially in the network details screen because there is less space.
I also fixed the chevron icon. It was pointing in the wrong direction when expanding objects. Now it points to the right when collapsed or down when expanded, like most tree views (e.g. Android Studios file tree).