### PR TITLE
Make DashboardScope accept Flow instead of StateFlow

### DIFF
--- a/FloconAndroid/flocon-base/src/commonMain/kotlin/io/github/openflocon/flocon/plugins/dashboard/model/DashboardScope.kt
+++ b/FloconAndroid/flocon-base/src/commonMain/kotlin/io/github/openflocon/flocon/plugins/dashboard/model/DashboardScope.kt
@@ -3,7 +3,6 @@ package io.github.openflocon.flocon.plugins.dashboard.model
 import io.github.openflocon.flocon.plugins.dashboard.builder.FormBuilder
 import io.github.openflocon.flocon.plugins.dashboard.builder.SectionBuilder
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
 
 interface DashboardScope {
     fun <T> section(name: String, flow: Flow<T>, content: SectionBuilder.(T) -> Unit)

--- a/FloconAndroid/flocon/src/commonMain/kotlin/io/github/openflocon/flocon/plugins/dashboard/FloconDashboardDSL.kt
+++ b/FloconAndroid/flocon/src/commonMain/kotlin/io/github/openflocon/flocon/plugins/dashboard/FloconDashboardDSL.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map


### PR DESCRIPTION
The `section` and `form` functions in the `DashboardScope` currently expect a `StateFlow`, but internally it is just used like a regular `Flow`. Sometimes the user has regular flows and it is a bit inconvenient to convert those to StateFlows, instead of just passing them directly to `section`.