### PR TITLE
Fix empty NavDisplay backstack by removing redundant onBack calls

### DIFF
--- a/FloconDesktop/library/designsystem/src/commonMain/kotlin/io/github/openflocon/library/designsystem/components/panel/FloconPanel.kt
+++ b/FloconDesktop/library/designsystem/src/commonMain/kotlin/io/github/openflocon/library/designsystem/components/panel/FloconPanel.kt
@@ -101,7 +101,6 @@ fun FloconPanel(
     EscapeHandler {
         coroutineScope.launch {
             state.hide()
-            onDismissRequest()
         }
         true
     }

--- a/FloconDesktop/navigation/src/commonMain/kotlin/io/github/openflocon/navigation/scene/PanelScene.kt
+++ b/FloconDesktop/navigation/src/commonMain/kotlin/io/github/openflocon/navigation/scene/PanelScene.kt
@@ -54,7 +54,6 @@ data class PanelScene(
                         onClick = {
                             scope.launch {
                                 state.hide()
-                                onBack()
                             }
                         },
                         modifier = Modifier
@@ -70,7 +69,6 @@ data class PanelScene(
                                 scope.launch {
                                     onPin.onPin()
                                     state.hide()
-                                    onBack()
                                 }
                             },
                             modifier = Modifier


### PR DESCRIPTION
Starting with version 1.8.0 of Flocon everytime the `Panel` is closed an `IllegalArgumentException` is thrown:

```
java.lang.IllegalArgumentException: NavDisplay backstack cannot be empty
	at androidx.navigation3.ui.NavDisplayKt__NavDisplayKt.NavDisplay(NavDisplay.kt:359)
	at androidx.navigation3.ui.NavDisplayKt.NavDisplay(Unknown Source)
	at androidx.navigation3.ui.NavDisplayKt__NavDisplayKt.NavDisplay$lambda$4$NavDisplayKt__NavDisplayKt(NavDisplay.kt)
	at androidx.compose.runtime.RecomposeScopeImpl.compose(RecomposeScopeImpl.kt:204)
	at androidx.compose.runtime.GapComposer.recomposeToGroupEnd(GapComposer.kt:1678)
	at androidx.compose.runtime.GapComposer.skipCurrentGroup(GapComposer.kt:2014)
	at androidx.compose.runtime.GapComposer.doCompose-aFTiNEg(GapComposer.kt:2655)
	at androidx.compose.runtime.GapComposer.recompose-aFTiNEg$runtime(GapComposer.kt:2577)
```

This should be related to the fact that `onBack` was triggered multiple times. Removing it from the `onClick` callbacks fixes this issue.