### PR TITLE
feat: Add HTTP API to export captured network logs

### DIFF
--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/datasource/NetworkLocalDataSource.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/datasource/NetworkLocalDataSource.kt
@@ -55,7 +55,11 @@ interface NetworkLocalDataSource {
     suspend fun deleteRequestOnDifferentSession(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel)
 
     // Returns (deviceId, call) pairs so callers can know which device each call belongs to
-    suspend fun getAllRequests(deviceId: String? = null): List<Pair<String, FloconNetworkCallDomainModel>>
+    suspend fun getAllRequests(
+        deviceId: String? = null,
+        startTimestamp: Long? = null,
+        endTimestamp: Long? = null,
+    ): List<Pair<String, FloconNetworkCallDomainModel>>
 
     suspend fun clear()
 }

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/datasource/NetworkLocalDataSource.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/datasource/NetworkLocalDataSource.kt
@@ -54,5 +54,8 @@ interface NetworkLocalDataSource {
 
     suspend fun deleteRequestOnDifferentSession(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel)
 
+    // Returns (deviceId, call) pairs so callers can know which device each call belongs to
+    suspend fun getAllRequests(deviceId: String? = null): List<Pair<String, FloconNetworkCallDomainModel>>
+
     suspend fun clear()
 }

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/datasource/NetworkLocalDataSource.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/datasource/NetworkLocalDataSource.kt
@@ -3,6 +3,7 @@ package io.github.openflocon.data.core.network.datasource
 import androidx.paging.PagingData
 import io.github.openflocon.domain.device.models.DeviceIdAndPackageNameDomainModel
 import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
+import io.github.openflocon.domain.network.models.NetworkCallWithDeviceId
 import io.github.openflocon.domain.network.models.NetworkFilterDomainModel
 import io.github.openflocon.domain.network.models.NetworkSortDomainModel
 import kotlinx.coroutines.flow.Flow
@@ -54,12 +55,11 @@ interface NetworkLocalDataSource {
 
     suspend fun deleteRequestOnDifferentSession(deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel)
 
-    // Returns (deviceId, call) pairs so callers can know which device each call belongs to
     suspend fun getAllRequests(
         deviceId: String? = null,
         startTimestamp: Long? = null,
         endTimestamp: Long? = null,
-    ): List<Pair<String, FloconNetworkCallDomainModel>>
+    ): List<NetworkCallWithDeviceId>
 
     suspend fun clear()
 }

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/repository/NetworkRepositoryImpl.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/repository/NetworkRepositoryImpl.kt
@@ -98,6 +98,11 @@ class NetworkRepositoryImpl(
             )
     }
 
+    override suspend fun getAllNetworkCalls(deviceId: String?): List<Pair<String, FloconNetworkCallDomainModel>> =
+        withContext(dispatcherProvider.data) {
+            networkLocalDataSource.getAllRequests(deviceId)
+        }
+
     override suspend fun getRequests(
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,
         ids: List<String>

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/repository/NetworkRepositoryImpl.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/repository/NetworkRepositoryImpl.kt
@@ -15,6 +15,7 @@ import io.github.openflocon.domain.messages.repository.MessagesReceiverRepositor
 import io.github.openflocon.domain.network.models.BadQualityConfigDomainModel
 import io.github.openflocon.domain.network.models.BadQualityConfigId
 import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
+import io.github.openflocon.domain.network.models.NetworkCallWithDeviceId
 import io.github.openflocon.domain.network.models.FloconNetworkResponseOnlyDomainModel
 import io.github.openflocon.domain.network.models.MockNetworkDomainModel
 import io.github.openflocon.domain.network.models.NetworkFilterDomainModel
@@ -102,7 +103,7 @@ class NetworkRepositoryImpl(
         deviceId: String?,
         startTimestamp: Long?,
         endTimestamp: Long?,
-    ): List<Pair<String, FloconNetworkCallDomainModel>> =
+    ): List<NetworkCallWithDeviceId> =
         withContext(dispatcherProvider.data) {
             networkLocalDataSource.getAllRequests(deviceId, startTimestamp, endTimestamp)
         }

--- a/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/repository/NetworkRepositoryImpl.kt
+++ b/FloconDesktop/data/core/src/commonMain/kotlin/io/github/openflocon/data/core/network/repository/NetworkRepositoryImpl.kt
@@ -98,9 +98,13 @@ class NetworkRepositoryImpl(
             )
     }
 
-    override suspend fun getAllNetworkCalls(deviceId: String?): List<Pair<String, FloconNetworkCallDomainModel>> =
+    override suspend fun getAllNetworkCalls(
+        deviceId: String?,
+        startTimestamp: Long?,
+        endTimestamp: Long?,
+    ): List<Pair<String, FloconNetworkCallDomainModel>> =
         withContext(dispatcherProvider.data) {
-            networkLocalDataSource.getAllRequests(deviceId)
+            networkLocalDataSource.getAllRequests(deviceId, startTimestamp, endTimestamp)
         }
 
     override suspend fun getRequests(

--- a/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/dao/FloconNetworkDao.kt
+++ b/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/dao/FloconNetworkDao.kt
@@ -68,6 +68,18 @@ interface FloconNetworkDao {
         callId: String,
     ): FloconNetworkCallEntity?
 
+    @Query("SELECT * FROM FloconNetworkCallEntity ORDER BY request_startTime ASC")
+    suspend fun getAllRequests(): List<FloconNetworkCallEntity>
+
+    @Query(
+        """
+        SELECT * FROM FloconNetworkCallEntity
+        WHERE deviceId = :deviceId
+        ORDER BY request_startTime ASC
+    """,
+    )
+    suspend fun getAllRequestsByDevice(deviceId: String): List<FloconNetworkCallEntity>
+
     @Query("DELETE FROM FloconNetworkCallEntity")
     suspend fun clearAll()
 

--- a/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/dao/FloconNetworkDao.kt
+++ b/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/dao/FloconNetworkDao.kt
@@ -68,17 +68,33 @@ interface FloconNetworkDao {
         callId: String,
     ): FloconNetworkCallEntity?
 
-    @Query("SELECT * FROM FloconNetworkCallEntity ORDER BY request_startTime ASC")
-    suspend fun getAllRequests(): List<FloconNetworkCallEntity>
+    @Query(
+        """
+        SELECT * FROM FloconNetworkCallEntity
+        WHERE (:startTimestamp IS NULL OR request_startTime >= :startTimestamp)
+        AND (:endTimestamp IS NULL OR request_startTime <= :endTimestamp)
+        ORDER BY request_startTime ASC
+    """,
+    )
+    suspend fun getAllRequests(
+        startTimestamp: Long? = null,
+        endTimestamp: Long? = null,
+    ): List<FloconNetworkCallEntity>
 
     @Query(
         """
         SELECT * FROM FloconNetworkCallEntity
         WHERE deviceId = :deviceId
+        AND (:startTimestamp IS NULL OR request_startTime >= :startTimestamp)
+        AND (:endTimestamp IS NULL OR request_startTime <= :endTimestamp)
         ORDER BY request_startTime ASC
     """,
     )
-    suspend fun getAllRequestsByDevice(deviceId: String): List<FloconNetworkCallEntity>
+    suspend fun getAllRequestsByDevice(
+        deviceId: String,
+        startTimestamp: Long? = null,
+        endTimestamp: Long? = null,
+    ): List<FloconNetworkCallEntity>
 
     @Query("DELETE FROM FloconNetworkCallEntity")
     suspend fun clearAll()

--- a/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/datasource/NetworkLocalDataSourceRoom.kt
+++ b/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/datasource/NetworkLocalDataSourceRoom.kt
@@ -260,6 +260,17 @@ class NetworkLocalDataSourceRoom(
         )
     }
 
+    override suspend fun getAllRequests(deviceId: String?): List<Pair<String, FloconNetworkCallDomainModel>> {
+        val entities = if (deviceId != null) {
+            floconNetworkDao.getAllRequestsByDevice(deviceId)
+        } else {
+            floconNetworkDao.getAllRequests()
+        }
+        return entities.mapNotNull { entity ->
+            entity.toDomainModel()?.let { domain -> entity.deviceId to domain }
+        }
+    }
+
     override suspend fun clear() {
         floconNetworkDao.clearAll()
     }

--- a/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/datasource/NetworkLocalDataSourceRoom.kt
+++ b/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/datasource/NetworkLocalDataSourceRoom.kt
@@ -12,6 +12,7 @@ import io.github.openflocon.data.local.network.mapper.toEntity
 import io.github.openflocon.data.local.network.models.FloconNetworkCallEntity
 import io.github.openflocon.domain.device.models.DeviceIdAndPackageNameDomainModel
 import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
+import io.github.openflocon.domain.network.models.NetworkCallWithDeviceId
 import io.github.openflocon.domain.network.models.NetworkFilterDomainModel
 import io.github.openflocon.domain.network.models.NetworkSortDomainModel
 import io.github.openflocon.domain.network.models.NetworkTextFilterColumns
@@ -264,14 +265,16 @@ class NetworkLocalDataSourceRoom(
         deviceId: String?,
         startTimestamp: Long?,
         endTimestamp: Long?,
-    ): List<Pair<String, FloconNetworkCallDomainModel>> {
+    ): List<NetworkCallWithDeviceId> {
         val entities = if (deviceId != null) {
             floconNetworkDao.getAllRequestsByDevice(deviceId, startTimestamp, endTimestamp)
         } else {
             floconNetworkDao.getAllRequests(startTimestamp, endTimestamp)
         }
         return entities.mapNotNull { entity ->
-            entity.toDomainModel()?.let { domain -> entity.deviceId to domain }
+            entity.toDomainModel()?.let { domain ->
+                NetworkCallWithDeviceId(deviceId = entity.deviceId, call = domain)
+            }
         }
     }
 

--- a/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/datasource/NetworkLocalDataSourceRoom.kt
+++ b/FloconDesktop/data/local/src/commonMain/kotlin/io/github/openflocon/data/local/network/datasource/NetworkLocalDataSourceRoom.kt
@@ -260,11 +260,15 @@ class NetworkLocalDataSourceRoom(
         )
     }
 
-    override suspend fun getAllRequests(deviceId: String?): List<Pair<String, FloconNetworkCallDomainModel>> {
+    override suspend fun getAllRequests(
+        deviceId: String?,
+        startTimestamp: Long?,
+        endTimestamp: Long?,
+    ): List<Pair<String, FloconNetworkCallDomainModel>> {
         val entities = if (deviceId != null) {
-            floconNetworkDao.getAllRequestsByDevice(deviceId)
+            floconNetworkDao.getAllRequestsByDevice(deviceId, startTimestamp, endTimestamp)
         } else {
-            floconNetworkDao.getAllRequests()
+            floconNetworkDao.getAllRequests(startTimestamp, endTimestamp)
         }
         return entities.mapNotNull { entity ->
             entity.toDomainModel()?.let { domain -> entity.deviceId to domain }

--- a/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/messages/DI.kt
+++ b/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/messages/DI.kt
@@ -12,7 +12,7 @@ internal val messagesModule = module {
     single<Server> {
         getServer(
             json = get(),
-            networkRepository = get()
+            networkRepository = lazy { get() },
         )
     }
     singleOf(::MessageRemoteDataSourceImpl) bind MessageRemoteDataSource::class

--- a/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/messages/DI.kt
+++ b/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/messages/DI.kt
@@ -11,7 +11,8 @@ import org.koin.dsl.module
 internal val messagesModule = module {
     single<Server> {
         getServer(
-            json = get()
+            json = get(),
+            networkRepository = get()
         )
     }
     singleOf(::MessageRemoteDataSourceImpl) bind MessageRemoteDataSource::class

--- a/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/models/NetworkLogsExportModel.kt
+++ b/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/models/NetworkLogsExportModel.kt
@@ -3,27 +3,27 @@ package com.flocon.data.remote.models
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class NetworkLogsExportResponse(
+internal data class NetworkLogsExportResponse(
     val data: List<NetworkCallExport>,
     val metadata: ExportMetadata,
 )
 
 @Serializable
-data class ExportMetadata(
+internal data class ExportMetadata(
     val exportedAt: Long,
     val totalItems: Int,
     val filteredBy: FilterCriteria?,
 )
 
 @Serializable
-data class FilterCriteria(
+internal data class FilterCriteria(
     val deviceId: String? = null,
     val startTimestamp: Long? = null,
     val endTimestamp: Long? = null,
 )
 
 @Serializable
-data class NetworkCallExport(
+internal data class NetworkCallExport(
     val callId: String,
     val method: String,
     val url: String,

--- a/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/models/NetworkLogsExportModel.kt
+++ b/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/models/NetworkLogsExportModel.kt
@@ -1,0 +1,41 @@
+package com.flocon.data.remote.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NetworkLogsExportResponse(
+    val data: List<NetworkCallExport>,
+    val metadata: ExportMetadata,
+)
+
+@Serializable
+data class ExportMetadata(
+    val exportedAt: Long,
+    val totalItems: Int,
+    val filteredBy: FilterCriteria?,
+)
+
+@Serializable
+data class FilterCriteria(
+    val deviceId: String? = null,
+    val startTimestamp: Long? = null,
+    val endTimestamp: Long? = null,
+)
+
+@Serializable
+data class NetworkCallExport(
+    val callId: String,
+    val method: String,
+    val url: String,
+    val startTime: Long,
+    val startTimeFormatted: String,
+    val statusCode: Int? = null,
+    val durationMs: Double? = null,
+    val requestHeaders: Map<String, String>,
+    val responseHeaders: Map<String, String>? = null,
+    val requestBody: String? = null,
+    val responseBody: String? = null,
+    val contentType: String? = null,
+    val deviceId: String,
+    val appInstance: Long,
+)

--- a/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/server/Server.kt
+++ b/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/server/Server.kt
@@ -5,6 +5,7 @@ import com.flocon.data.remote.models.FloconIncomingMessageDataModel
 import com.flocon.data.remote.models.FloconOutgoingMessageDataModel
 import io.github.openflocon.domain.Constant
 import io.github.openflocon.domain.messages.models.FloconReceivedFileDomainModel
+import io.github.openflocon.domain.network.repository.NetworkRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.Json
 import kotlin.uuid.ExperimentalUuidApi
@@ -31,4 +32,7 @@ interface Server {
 @OptIn(ExperimentalUuidApi::class)
 fun newRequestId(): String = Uuid.random().toString()
 
-expect fun getServer(json: Json): Server
+expect fun getServer(
+    json: Json,
+    networkRepository: NetworkRepository,
+): Server

--- a/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/server/Server.kt
+++ b/FloconDesktop/data/remote/src/commonMain/kotlin/com/flocon/data/remote/server/Server.kt
@@ -34,5 +34,5 @@ fun newRequestId(): String = Uuid.random().toString()
 
 expect fun getServer(
     json: Json,
-    networkRepository: NetworkRepository,
+    networkRepository: Lazy<NetworkRepository>,
 ): Server

--- a/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/NetworkExportEndpoint.kt
+++ b/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/NetworkExportEndpoint.kt
@@ -8,40 +8,44 @@ import com.flocon.data.remote.models.NetworkLogsExportResponse
 import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
-import io.ktor.server.response.respondText
+import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 fun Route.networkExportRoutes(
     json: Json,
-    getNetworkCalls: suspend (deviceId: String?) -> List<Pair<String, FloconNetworkCallDomainModel>>,
+    // Filtering is done at DB level — timestamps passed through to the query
+    getNetworkCalls: suspend (deviceId: String?, startTimestamp: Long?, endTimestamp: Long?) -> List<Pair<String, FloconNetworkCallDomainModel>>,
 ) {
     // 1. GET /api/network-logs — all calls from all devices
     get("/api/network-logs") {
-        val calls = getNetworkCalls(null)
+        val calls = getNetworkCalls(null, null, null)
         call.respondJson(json, calls, deviceId = null, startTimestamp = null, endTimestamp = null)
     }
 
     // 2. GET /api/network-logs/{deviceId} — all calls for a specific device
     get("/api/network-logs/{deviceId}") {
         val deviceId = call.parameters["deviceId"]
-        val calls = getNetworkCalls(deviceId)
+        val calls = getNetworkCalls(deviceId, null, null)
         call.respondJson(json, calls, deviceId = deviceId, startTimestamp = null, endTimestamp = null)
     }
 
-    // 3. GET /api/network-logs/{deviceId}?startTimestamp=&endTimestamp= — filtered by device + time range
+    // 3. GET /api/network-logs/{deviceId}/filter?startTimestamp=&endTimestamp= — device + time range
     get("/api/network-logs/{deviceId}/filter") {
         val deviceId = call.parameters["deviceId"]
         val startTimestamp = call.request.queryParameters["startTimestamp"]?.toLongOrNull()
         val endTimestamp = call.request.queryParameters["endTimestamp"]?.toLongOrNull()
 
-        val calls = getNetworkCalls(deviceId)
+        val calls = getNetworkCalls(deviceId, startTimestamp, endTimestamp)
         call.respondJson(json, calls, deviceId = deviceId, startTimestamp = startTimestamp, endTimestamp = endTimestamp)
     }
 }
 
-private suspend fun io.ktor.server.application.ApplicationCall.respondJson(
+private suspend fun ApplicationCall.respondJson(
     json: Json,
     calls: List<Pair<String, FloconNetworkCallDomainModel>>,
     deviceId: String?,
@@ -49,13 +53,7 @@ private suspend fun io.ktor.server.application.ApplicationCall.respondJson(
     endTimestamp: Long?,
 ) {
     try {
-        val filtered = calls.filter { (_, networkCall) ->
-            val matchesStart = startTimestamp == null || networkCall.request.startTime >= startTimestamp
-            val matchesEnd = endTimestamp == null || networkCall.request.startTime <= endTimestamp
-            matchesStart && matchesEnd
-        }
-
-        val exportedCalls = filtered.map { (storedDeviceId, networkCall) ->
+        val exportedCalls = calls.map { (storedDeviceId, networkCall) ->
             NetworkCallExport(
                 callId = networkCall.callId,
                 method = networkCall.request.method,
@@ -113,7 +111,10 @@ private suspend fun io.ktor.server.application.ApplicationCall.respondJson(
     } catch (e: Exception) {
         Logger.e("Error exporting network logs", e)
         respondText(
-            """{"error":"${e.message?.replace("\"", "\\\"")}"}""",
+            json.encodeToString(
+                MapSerializer(serializer<String>(), serializer<String>()),
+                mapOf("error" to (e.message ?: "Unknown error")),
+            ),
             ContentType.Application.Json,
             HttpStatusCode.InternalServerError,
         )

--- a/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/NetworkExportEndpoint.kt
+++ b/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/NetworkExportEndpoint.kt
@@ -6,6 +6,7 @@ import com.flocon.data.remote.models.FilterCriteria
 import com.flocon.data.remote.models.NetworkCallExport
 import com.flocon.data.remote.models.NetworkLogsExportResponse
 import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
+import io.github.openflocon.domain.network.models.NetworkCallWithDeviceId
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
@@ -19,7 +20,7 @@ import kotlinx.serialization.serializer
 fun Route.networkExportRoutes(
     json: Json,
     // Filtering is done at DB level — timestamps passed through to the query
-    getNetworkCalls: suspend (deviceId: String?, startTimestamp: Long?, endTimestamp: Long?) -> List<Pair<String, FloconNetworkCallDomainModel>>,
+    getNetworkCalls: suspend (deviceId: String?, startTimestamp: Long?, endTimestamp: Long?) -> List<NetworkCallWithDeviceId>,
 ) {
     // 1. GET /api/network-logs — all calls from all devices
     get("/api/network-logs") {
@@ -47,13 +48,15 @@ fun Route.networkExportRoutes(
 
 private suspend fun ApplicationCall.respondJson(
     json: Json,
-    calls: List<Pair<String, FloconNetworkCallDomainModel>>,
+    calls: List<NetworkCallWithDeviceId>,
     deviceId: String?,
     startTimestamp: Long?,
     endTimestamp: Long?,
 ) {
     try {
-        val exportedCalls = calls.map { (storedDeviceId, networkCall) ->
+        val exportedCalls = calls.map { networkCallWithDeviceId ->
+            val networkCall = networkCallWithDeviceId.call
+            val storedDeviceId = networkCallWithDeviceId.deviceId
             NetworkCallExport(
                 callId = networkCall.callId,
                 method = networkCall.request.method,

--- a/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/NetworkExportEndpoint.kt
+++ b/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/NetworkExportEndpoint.kt
@@ -6,89 +6,116 @@ import com.flocon.data.remote.models.FilterCriteria
 import com.flocon.data.remote.models.NetworkCallExport
 import com.flocon.data.remote.models.NetworkLogsExportResponse
 import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.response.respondText
+import kotlinx.serialization.json.Json
 
 fun Route.networkExportRoutes(
-    getNetworkCalls: suspend () -> List<FloconNetworkCallDomainModel>,
+    json: Json,
+    getNetworkCalls: suspend (deviceId: String?) -> List<Pair<String, FloconNetworkCallDomainModel>>,
 ) {
-    get("/api/export/network-logs") {
-        try {
-            val deviceId = call.request.queryParameters["deviceId"]
-            val startTimestamp = call.request.queryParameters["startTimestamp"]?.toLongOrNull()
-            val endTimestamp = call.request.queryParameters["endTimestamp"]?.toLongOrNull()
+    // 1. GET /api/network-logs — all calls from all devices
+    get("/api/network-logs") {
+        val calls = getNetworkCalls(null)
+        call.respondJson(json, calls, deviceId = null, startTimestamp = null, endTimestamp = null)
+    }
 
-            val allCalls = getNetworkCalls()
-            
-            val filtered = allCalls.filter { call ->
-                val matchesDevice = deviceId == null || call.appInstance.deviceId == deviceId
-                val matchesStartTime = startTimestamp == null || call.request.startTime >= startTimestamp
-                val matchesEndTime = endTimestamp == null || call.request.startTime <= endTimestamp
-                
-                matchesDevice && matchesStartTime && matchesEndTime
-            }
+    // 2. GET /api/network-logs/{deviceId} — all calls for a specific device
+    get("/api/network-logs/{deviceId}") {
+        val deviceId = call.parameters["deviceId"]
+        val calls = getNetworkCalls(deviceId)
+        call.respondJson(json, calls, deviceId = deviceId, startTimestamp = null, endTimestamp = null)
+    }
 
-            val exportedCalls = filtered.map { call ->
-                NetworkCallExport(
-                    callId = call.callId,
-                    method = call.request.method,
-                    url = call.request.url,
-                    startTime = call.request.startTime,
-                    startTimeFormatted = call.request.startTimeFormatted,
-                    statusCode = when (val response = call.response) {
-                        is FloconNetworkCallDomainModel.Response.Success -> 
-                            when (val info = response.specificInfos) {
-                                is FloconNetworkCallDomainModel.Response.Success.SpecificInfos.Http -> info.httpCode
-                                else -> null
-                            }
-                        else -> null
-                    },
-                    durationMs = call.response?.durationMs,
-                    requestHeaders = call.request.headers,
-                    responseHeaders = when (val response = call.response) {
-                        is FloconNetworkCallDomainModel.Response.Success -> response.headers
-                        else -> null
-                    },
-                    requestBody = call.request.body,
-                    responseBody = when (val response = call.response) {
-                        is FloconNetworkCallDomainModel.Response.Success -> response.body
-                        else -> null
-                    },
-                    contentType = when (val response = call.response) {
-                        is FloconNetworkCallDomainModel.Response.Success -> response.contentType
-                        else -> null
-                    },
-                    deviceId = call.appInstance.deviceId,
-                    appInstance = call.appInstance.appInstance,
-                )
-            }
+    // 3. GET /api/network-logs/{deviceId}?startTimestamp=&endTimestamp= — filtered by device + time range
+    get("/api/network-logs/{deviceId}/filter") {
+        val deviceId = call.parameters["deviceId"]
+        val startTimestamp = call.request.queryParameters["startTimestamp"]?.toLongOrNull()
+        val endTimestamp = call.request.queryParameters["endTimestamp"]?.toLongOrNull()
 
-            val response = NetworkLogsExportResponse(
-                data = exportedCalls,
-                metadata = ExportMetadata(
-                    exportedAt = System.currentTimeMillis(),
-                    totalItems = exportedCalls.size,
-                    filteredBy = if (deviceId != null || startTimestamp != null || endTimestamp != null) {
-                        FilterCriteria(
-                            deviceId = deviceId,
-                            startTimestamp = startTimestamp,
-                            endTimestamp = endTimestamp,
-                        )
-                    } else {
-                        null
-                    },
-                ),
-            )
+        val calls = getNetworkCalls(deviceId)
+        call.respondJson(json, calls, deviceId = deviceId, startTimestamp = startTimestamp, endTimestamp = endTimestamp)
+    }
+}
 
-            call.respond(HttpStatusCode.OK, response)
-        } catch (e: Exception) {
-            Logger.e("Error exporting network logs", e)
-            call.respond(
-                HttpStatusCode.InternalServerError,
-                mapOf("error" to (e.message ?: "Unknown error"))
+private suspend fun io.ktor.server.application.ApplicationCall.respondJson(
+    json: Json,
+    calls: List<Pair<String, FloconNetworkCallDomainModel>>,
+    deviceId: String?,
+    startTimestamp: Long?,
+    endTimestamp: Long?,
+) {
+    try {
+        val filtered = calls.filter { (_, networkCall) ->
+            val matchesStart = startTimestamp == null || networkCall.request.startTime >= startTimestamp
+            val matchesEnd = endTimestamp == null || networkCall.request.startTime <= endTimestamp
+            matchesStart && matchesEnd
+        }
+
+        val exportedCalls = filtered.map { (storedDeviceId, networkCall) ->
+            NetworkCallExport(
+                callId = networkCall.callId,
+                method = networkCall.request.method,
+                url = networkCall.request.url,
+                startTime = networkCall.request.startTime,
+                startTimeFormatted = networkCall.request.startTimeFormatted,
+                statusCode = when (val response = networkCall.response) {
+                    is FloconNetworkCallDomainModel.Response.Success ->
+                        when (val info = response.specificInfos) {
+                            is FloconNetworkCallDomainModel.Response.Success.SpecificInfos.Http -> info.httpCode
+                            else -> null
+                        }
+                    else -> null
+                },
+                durationMs = networkCall.response?.durationMs,
+                requestHeaders = networkCall.request.headers,
+                responseHeaders = when (val response = networkCall.response) {
+                    is FloconNetworkCallDomainModel.Response.Success -> response.headers
+                    else -> null
+                },
+                requestBody = networkCall.request.body,
+                responseBody = when (val response = networkCall.response) {
+                    is FloconNetworkCallDomainModel.Response.Success -> response.body
+                    else -> null
+                },
+                contentType = when (val response = networkCall.response) {
+                    is FloconNetworkCallDomainModel.Response.Success -> response.contentType
+                    else -> null
+                },
+                deviceId = storedDeviceId,
+                appInstance = networkCall.appInstance,
             )
         }
+
+        val response = NetworkLogsExportResponse(
+            data = exportedCalls,
+            metadata = ExportMetadata(
+                exportedAt = System.currentTimeMillis(),
+                totalItems = exportedCalls.size,
+                filteredBy = if (deviceId != null || startTimestamp != null || endTimestamp != null) {
+                    FilterCriteria(
+                        deviceId = deviceId,
+                        startTimestamp = startTimestamp,
+                        endTimestamp = endTimestamp,
+                    )
+                } else null,
+            ),
+        )
+
+        respondText(
+            json.encodeToString(NetworkLogsExportResponse.serializer(), response),
+            ContentType.Application.Json,
+            HttpStatusCode.OK,
+        )
+    } catch (e: Exception) {
+        Logger.e("Error exporting network logs", e)
+        respondText(
+            """{"error":"${e.message?.replace("\"", "\\\"")}"}""",
+            ContentType.Application.Json,
+            HttpStatusCode.InternalServerError,
+        )
     }
 }

--- a/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/NetworkExportEndpoint.kt
+++ b/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/NetworkExportEndpoint.kt
@@ -1,0 +1,94 @@
+package com.flocon.data.remote.server
+
+import co.touchlab.kermit.Logger
+import com.flocon.data.remote.models.ExportMetadata
+import com.flocon.data.remote.models.FilterCriteria
+import com.flocon.data.remote.models.NetworkCallExport
+import com.flocon.data.remote.models.NetworkLogsExportResponse
+import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+
+fun Route.networkExportRoutes(
+    getNetworkCalls: suspend () -> List<FloconNetworkCallDomainModel>,
+) {
+    get("/api/export/network-logs") {
+        try {
+            val deviceId = call.request.queryParameters["deviceId"]
+            val startTimestamp = call.request.queryParameters["startTimestamp"]?.toLongOrNull()
+            val endTimestamp = call.request.queryParameters["endTimestamp"]?.toLongOrNull()
+
+            val allCalls = getNetworkCalls()
+            
+            val filtered = allCalls.filter { call ->
+                val matchesDevice = deviceId == null || call.appInstance.deviceId == deviceId
+                val matchesStartTime = startTimestamp == null || call.request.startTime >= startTimestamp
+                val matchesEndTime = endTimestamp == null || call.request.startTime <= endTimestamp
+                
+                matchesDevice && matchesStartTime && matchesEndTime
+            }
+
+            val exportedCalls = filtered.map { call ->
+                NetworkCallExport(
+                    callId = call.callId,
+                    method = call.request.method,
+                    url = call.request.url,
+                    startTime = call.request.startTime,
+                    startTimeFormatted = call.request.startTimeFormatted,
+                    statusCode = when (val response = call.response) {
+                        is FloconNetworkCallDomainModel.Response.Success -> 
+                            when (val info = response.specificInfos) {
+                                is FloconNetworkCallDomainModel.Response.Success.SpecificInfos.Http -> info.httpCode
+                                else -> null
+                            }
+                        else -> null
+                    },
+                    durationMs = call.response?.durationMs,
+                    requestHeaders = call.request.headers,
+                    responseHeaders = when (val response = call.response) {
+                        is FloconNetworkCallDomainModel.Response.Success -> response.headers
+                        else -> null
+                    },
+                    requestBody = call.request.body,
+                    responseBody = when (val response = call.response) {
+                        is FloconNetworkCallDomainModel.Response.Success -> response.body
+                        else -> null
+                    },
+                    contentType = when (val response = call.response) {
+                        is FloconNetworkCallDomainModel.Response.Success -> response.contentType
+                        else -> null
+                    },
+                    deviceId = call.appInstance.deviceId,
+                    appInstance = call.appInstance.appInstance,
+                )
+            }
+
+            val response = NetworkLogsExportResponse(
+                data = exportedCalls,
+                metadata = ExportMetadata(
+                    exportedAt = System.currentTimeMillis(),
+                    totalItems = exportedCalls.size,
+                    filteredBy = if (deviceId != null || startTimestamp != null || endTimestamp != null) {
+                        FilterCriteria(
+                            deviceId = deviceId,
+                            startTimestamp = startTimestamp,
+                            endTimestamp = endTimestamp,
+                        )
+                    } else {
+                        null
+                    },
+                ),
+            )
+
+            call.respond(HttpStatusCode.OK, response)
+        } catch (e: Exception) {
+            Logger.e("Error exporting network logs", e)
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                mapOf("error" to (e.message ?: "Unknown error"))
+            )
+        }
+    }
+}

--- a/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/Server.desktop.kt
+++ b/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/Server.desktop.kt
@@ -1,5 +1,9 @@
 package com.flocon.data.remote.server
 
+import io.github.openflocon.domain.network.repository.NetworkRepository
 import kotlinx.serialization.json.Json
 
-actual fun getServer(json: Json): Server = ServerJvm(json)
+actual fun getServer(
+    json: Json,
+    networkRepository: NetworkRepository,
+): Server = ServerJvm(json, networkRepository)

--- a/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/Server.desktop.kt
+++ b/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/Server.desktop.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.json.Json
 
 actual fun getServer(
     json: Json,
-    networkRepository: NetworkRepository,
+    networkRepository: Lazy<NetworkRepository>,
 ): Server = ServerJvm(json, networkRepository)

--- a/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/ServerJvm.kt
+++ b/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/ServerJvm.kt
@@ -257,8 +257,8 @@ class ServerJvm(
                 // Add network export routes
                 networkExportRoutes(
                     json = json,
-                    getNetworkCalls = { deviceId ->
-                        networkRepository.value.getAllNetworkCalls(deviceId)
+                    getNetworkCalls = { deviceId, startTimestamp, endTimestamp ->
+                        networkRepository.value.getAllNetworkCalls(deviceId, startTimestamp, endTimestamp)
                     }
                 )
             }

--- a/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/ServerJvm.kt
+++ b/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/ServerJvm.kt
@@ -42,7 +42,7 @@ import kotlin.time.Duration.Companion.seconds
 
 class ServerJvm(
     private val json: Json,
-    private val networkRepository: NetworkRepository,
+    private val networkRepository: Lazy<NetworkRepository>,
 ) : Server {
     private val _receivedMessages = Channel<FloconIncomingMessageDataModel>()
     override val receivedMessages = _receivedMessages.receiveAsFlow()
@@ -256,7 +256,10 @@ class ServerJvm(
                 
                 // Add network export routes
                 networkExportRoutes(
-                    getNetworkCalls = { networkRepository.getNetworkCalls() }
+                    json = json,
+                    getNetworkCalls = { deviceId ->
+                        networkRepository.value.getAllNetworkCalls(deviceId)
+                    }
                 )
             }
         }.start(wait = false)

--- a/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/ServerJvm.kt
+++ b/FloconDesktop/data/remote/src/desktopMain/kotlin/com/flocon/data/remote/server/ServerJvm.kt
@@ -5,6 +5,7 @@ import com.flocon.data.remote.models.FloconDeviceIdAndPackageNameDataModel
 import com.flocon.data.remote.models.FloconIncomingMessageDataModel
 import com.flocon.data.remote.models.FloconOutgoingMessageDataModel
 import io.github.openflocon.domain.messages.models.FloconReceivedFileDomainModel
+import io.github.openflocon.domain.network.repository.NetworkRepository
 import io.ktor.http.content.PartData
 import io.ktor.http.content.forEachPart
 import io.ktor.http.content.streamProvider
@@ -41,6 +42,7 @@ import kotlin.time.Duration.Companion.seconds
 
 class ServerJvm(
     private val json: Json,
+    private val networkRepository: NetworkRepository,
 ) : Server {
     private val _receivedMessages = Channel<FloconIncomingMessageDataModel>()
     override val receivedMessages = _receivedMessages.receiveAsFlow()
@@ -251,6 +253,11 @@ class ServerJvm(
 
                     call.respondText("file received : ${savedFile?.absolutePath ?: "inconnu"}")
                 }
+                
+                // Add network export routes
+                networkExportRoutes(
+                    getNetworkCalls = { networkRepository.getNetworkCalls() }
+                )
             }
         }.start(wait = false)
 

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/common/time/TimeFormatter.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/common/time/TimeFormatter.kt
@@ -29,8 +29,8 @@ fun formatDate(timestamp: Long): String {
     val instant = Instant.fromEpochMilliseconds(timestamp)
     val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
 
-    val day = localDateTime.dayOfMonth
-    val month = localDateTime.monthNumber
+    val day = localDateTime.day
+    val month = localDateTime.month.number
     val year = localDateTime.year
 
     val hours = localDateTime.hour

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/common/time/TimeFormatter.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/common/time/TimeFormatter.kt
@@ -29,8 +29,8 @@ fun formatDate(timestamp: Long): String {
     val instant = Instant.fromEpochMilliseconds(timestamp)
     val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
 
-    val day = localDateTime.day
-    val month = localDateTime.month.number
+    val day = localDateTime.dayOfMonth
+    val month = localDateTime.monthNumber
     val year = localDateTime.year
 
     val hours = localDateTime.hour

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/models/NetworkCallWithDeviceId.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/models/NetworkCallWithDeviceId.kt
@@ -1,0 +1,6 @@
+package io.github.openflocon.domain.network.models
+
+data class NetworkCallWithDeviceId(
+    val deviceId: String,
+    val call: FloconNetworkCallDomainModel,
+)

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/repository/NetworkRepository.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/repository/NetworkRepository.kt
@@ -53,6 +53,9 @@ interface NetworkRepository {
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel
     )
 
+    // Returns (deviceId, call) pairs — deviceId comes from the stored record
+    suspend fun getAllNetworkCalls(deviceId: String? = null): List<Pair<String, FloconNetworkCallDomainModel>>
+
     suspend fun replayRequest(
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,
         request: FloconNetworkCallDomainModel

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/repository/NetworkRepository.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/repository/NetworkRepository.kt
@@ -3,6 +3,7 @@ package io.github.openflocon.domain.network.repository
 import androidx.paging.PagingData
 import io.github.openflocon.domain.device.models.DeviceIdAndPackageNameDomainModel
 import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
+import io.github.openflocon.domain.network.models.NetworkCallWithDeviceId
 import io.github.openflocon.domain.network.models.NetworkFilterDomainModel
 import io.github.openflocon.domain.network.models.NetworkSortDomainModel
 import kotlinx.coroutines.flow.Flow
@@ -53,12 +54,11 @@ interface NetworkRepository {
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel
     )
 
-    // Returns (deviceId, call) pairs — deviceId comes from the stored record
     suspend fun getAllNetworkCalls(
         deviceId: String? = null,
         startTimestamp: Long? = null,
         endTimestamp: Long? = null,
-    ): List<Pair<String, FloconNetworkCallDomainModel>>
+    ): List<NetworkCallWithDeviceId>
 
     suspend fun replayRequest(
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/repository/NetworkRepository.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/repository/NetworkRepository.kt
@@ -54,7 +54,11 @@ interface NetworkRepository {
     )
 
     // Returns (deviceId, call) pairs — deviceId comes from the stored record
-    suspend fun getAllNetworkCalls(deviceId: String? = null): List<Pair<String, FloconNetworkCallDomainModel>>
+    suspend fun getAllNetworkCalls(
+        deviceId: String? = null,
+        startTimestamp: Long? = null,
+        endTimestamp: Long? = null,
+    ): List<Pair<String, FloconNetworkCallDomainModel>>
 
     suspend fun replayRequest(
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/usecase/ExportNetworkLogsAsJsonUseCase.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/usecase/ExportNetworkLogsAsJsonUseCase.kt
@@ -8,7 +8,7 @@ import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
 import io.github.openflocon.domain.network.models.NetworkFilterDomainModel
 import io.github.openflocon.domain.network.repository.NetworkRepository
 
-class ExportNetworkLogsAsJsonUseCase(
+class ExportNetworkLogsAsJsonUseCase internal constructor(
     private val networkRepository: NetworkRepository,
 ) {
     suspend operator fun invoke(

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/usecase/ExportNetworkLogsAsJsonUseCase.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/usecase/ExportNetworkLogsAsJsonUseCase.kt
@@ -3,19 +3,33 @@ package io.github.openflocon.domain.network.usecase
 import io.github.openflocon.domain.common.Either
 import io.github.openflocon.domain.common.Failure
 import io.github.openflocon.domain.common.Success
+import io.github.openflocon.domain.device.models.DeviceIdAndPackageNameDomainModel
 import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
+import io.github.openflocon.domain.network.models.NetworkFilterDomainModel
 import io.github.openflocon.domain.network.repository.NetworkRepository
 
 class ExportNetworkLogsAsJsonUseCase(
     private val networkRepository: NetworkRepository,
 ) {
     suspend operator fun invoke(
+        deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,
         deviceId: String? = null,
         startTimestamp: Long? = null,
         endTimestamp: Long? = null,
     ): Either<Throwable, List<FloconNetworkCallDomainModel>> {
         return try {
-            val calls = networkRepository.getNetworkCalls()
+            val filter = NetworkFilterDomainModel(
+                statusCode = null,
+                contentType = null,
+                hasResponse = null,
+                searchText = null,
+                requestDate = null,
+            )
+            val calls = networkRepository.getRequests(
+                deviceIdAndPackageName = deviceIdAndPackageName,
+                sortedBy = null,
+                filter = filter,
+            )
             
             val filtered = calls.filter { call ->
                 val matchesDevice = deviceId == null || call.appInstance.deviceId == deviceId

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/usecase/ExportNetworkLogsAsJsonUseCase.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/usecase/ExportNetworkLogsAsJsonUseCase.kt
@@ -1,0 +1,37 @@
+package io.github.openflocon.domain.network.usecase
+
+import io.github.openflocon.domain.common.Either
+import io.github.openflocon.domain.common.Failure
+import io.github.openflocon.domain.common.Success
+import io.github.openflocon.domain.network.models.FloconNetworkCallDomainModel
+import io.github.openflocon.domain.network.repository.NetworkRepository
+
+class ExportNetworkLogsAsJsonUseCase(
+    private val networkRepository: NetworkRepository,
+) {
+    suspend operator fun invoke(
+        deviceId: String? = null,
+        startTimestamp: Long? = null,
+        endTimestamp: Long? = null,
+    ): Either<Throwable, List<FloconNetworkCallDomainModel>> {
+        return try {
+            val calls = networkRepository.getNetworkCalls()
+            
+            val filtered = calls.filter { call ->
+                val matchesDevice = deviceId == null || call.appInstance.deviceId == deviceId
+                val matchesStartTime = startTimestamp == null || call.request.startTime >= startTimestamp
+                val matchesEndTime = endTimestamp == null || call.request.startTime <= endTimestamp
+                
+                matchesDevice && matchesStartTime && matchesEndTime
+            }
+            
+            if (filtered.isEmpty()) {
+                return Failure(Throwable("No network logs found matching the criteria"))
+            }
+            
+            Success(filtered)
+        } catch (e: Exception) {
+            Failure(e)
+        }
+    }
+}

--- a/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/usecase/ExportNetworkLogsAsJsonUseCase.kt
+++ b/FloconDesktop/domain/src/commonMain/kotlin/io/github/openflocon/domain/network/usecase/ExportNetworkLogsAsJsonUseCase.kt
@@ -13,17 +13,16 @@ class ExportNetworkLogsAsJsonUseCase(
 ) {
     suspend operator fun invoke(
         deviceIdAndPackageName: DeviceIdAndPackageNameDomainModel,
-        deviceId: String? = null,
+        filterText: String? = null,
         startTimestamp: Long? = null,
         endTimestamp: Long? = null,
     ): Either<Throwable, List<FloconNetworkCallDomainModel>> {
         return try {
             val filter = NetworkFilterDomainModel(
-                statusCode = null,
-                contentType = null,
-                hasResponse = null,
-                searchText = null,
-                requestDate = null,
+                filterOnAllColumns = filterText,
+                textsFilters = null,
+                methodFilter = null,
+                displayOldSessions = true,
             )
             val calls = networkRepository.getRequests(
                 deviceIdAndPackageName = deviceIdAndPackageName,
@@ -32,11 +31,10 @@ class ExportNetworkLogsAsJsonUseCase(
             )
             
             val filtered = calls.filter { call ->
-                val matchesDevice = deviceId == null || call.appInstance.deviceId == deviceId
                 val matchesStartTime = startTimestamp == null || call.request.startTime >= startTimestamp
                 val matchesEndTime = endTimestamp == null || call.request.startTime <= endTimestamp
                 
-                matchesDevice && matchesStartTime && matchesEndTime
+                matchesStartTime && matchesEndTime
             }
             
             if (filtered.isEmpty()) {


### PR DESCRIPTION
## Summary

Adds a built-in HTTP export API to the Flocon desktop server, allowing 
external tools (test frameworks, CI pipelines, scripts) to query captured 
network logs directly over HTTP without opening the desktop UI.

## Endpoints

All endpoints are served on the existing HTTP server (port `9024`).

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/network-logs` | All captured network calls across all devices |
| `GET` | `/api/network-logs/{deviceId}` | All calls for a specific device |
| `GET` | `/api/network-logs/{deviceId}/filter` | Calls filtered by device and time range |

### Query Parameters (endpoint 3)
| Parameter | Type | Description |
|-----------|------|-------------|
| `startTimestamp` | `Long` (Unix ms) | Return calls at or after this time |
| `endTimestamp` | `Long` (Unix ms) | Return calls at or before this time |

### Example Response
```json
{
  "data": [
    {
      "callId": "7b6f09e6-...",
      "method": "GET",
      "url": "https://api.example.com/endpoint",
      "startTime": 1779192773561,
      "startTimeFormatted": "17:12:53.561",
      "statusCode": 200,
      "durationMs": 398.84,
      "requestHeaders": { "Authorization": "Bearer ..." },
      "responseHeaders": { "Content-Type": "application/json" },
      "requestBody": null,
      "responseBody": "{ ... }",
      "contentType": "application/json",
      "deviceId": "87b5d37fd3c32ce3",
      "appInstance": 1780479786702
    }
  ],
  "metadata": {
    "exportedAt": 1779200000000,
    "totalItems": 1,
    "filteredBy": {
      "deviceId": "87b5d37fd3c32ce3",
      "startTimestamp": 1779192773000,
      "endTimestamp": 1779199999999
    }
  }
}