### PR TITLE
Add background color to selected device and app

### DIFF
--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/app/ui/view/topbar/app/TopBarAppDropdown.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/app/ui/view/topbar/app/TopBarAppDropdown.kt
@@ -2,6 +2,7 @@
 
 package io.github.openflocon.flocondesktop.app.ui.view.topbar.app
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -18,6 +19,7 @@ import io.github.openflocon.flocondesktop.app.ui.model.AppsStateUiModel
 import io.github.openflocon.flocondesktop.app.ui.model.DeviceAppUiModel
 import io.github.openflocon.flocondesktop.app.ui.model.DevicesStateUiModel
 import io.github.openflocon.flocondesktop.app.ui.view.topbar.TopBarSelector
+import io.github.openflocon.library.designsystem.FloconTheme
 import io.github.openflocon.library.designsystem.components.FloconExposedDropdownMenu
 import io.github.openflocon.library.designsystem.components.FloconExposedDropdownMenuBox
 
@@ -72,10 +74,12 @@ internal fun TopBarAppDropdown(
                     ) {
                         appsState.apps
                             .fastForEach { app ->
+                                val isSelected = appsState.appSelected?.packageName == app.packageName
+
                                 TopBarAppView(
                                     deviceApp = app,
                                     platform = devicesState.deviceSelected.platform,
-                                    selected = appsState.appSelected?.packageName == app.packageName,
+                                    selected = isSelected,
                                     deleteClick = {
                                         deleteApp(app)
                                         expanded = false
@@ -86,6 +90,13 @@ internal fun TopBarAppDropdown(
                                             onAppSelected(app)
                                             expanded = false
                                         }
+                                        .run {
+                                            if(isSelected) {
+                                                background(color = FloconTheme.colorPalette.onTertiary)
+                                            } else {
+                                                this
+                                            }
+                                        },
                                 )
                             }
                     }

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/app/ui/view/topbar/app/TopBarAppDropdown.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/app/ui/view/topbar/app/TopBarAppDropdown.kt
@@ -90,13 +90,13 @@ internal fun TopBarAppDropdown(
                                             onAppSelected(app)
                                             expanded = false
                                         }
-                                        .run {
+                                        .then (
                                             if(isSelected) {
-                                                background(color = FloconTheme.colorPalette.onTertiary)
+                                                Modifier.background(color = FloconTheme.colorPalette.onTertiary)
                                             } else {
-                                                this
+                                                Modifier
                                             }
-                                        },
+                                        ),
                                 )
                             }
                     }

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/app/ui/view/topbar/device/TopBarDeviceDropdown.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/app/ui/view/topbar/device/TopBarDeviceDropdown.kt
@@ -74,13 +74,13 @@ internal fun TopBarDeviceDropdown(
                                 onDeviceSelected(device)
                                 expanded = false
                             }
-                            .run {
+                            .then(
                                 if(isSelected) {
-                                    background(color = FloconTheme.colorPalette.onTertiary)
+                                    Modifier.background(color = FloconTheme.colorPalette.onTertiary)
                                 } else {
-                                    this
+                                    Modifier
                                 }
-                            },
+                            ),
                         device = device,
                         selected = isSelected,
                         deleteClick = {

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/app/ui/view/topbar/device/TopBarDeviceDropdown.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/app/ui/view/topbar/device/TopBarDeviceDropdown.kt
@@ -2,6 +2,7 @@
 
 package io.github.openflocon.flocondesktop.app.ui.view.topbar.device
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -64,15 +65,24 @@ internal fun TopBarDeviceDropdown(
         ) {
             if (state is DevicesStateUiModel.WithDevices) {
                 state.devices.forEach { device ->
+                    val isSelected = state.deviceSelected.id == device.id
+
                     TopBarDeviceView(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
                                 onDeviceSelected(device)
                                 expanded = false
+                            }
+                            .run {
+                                if(isSelected) {
+                                    background(color = FloconTheme.colorPalette.onTertiary)
+                                } else {
+                                    this
+                                }
                             },
                         device = device,
-                        selected = state.deviceSelected.id == device.id,
+                        selected = isSelected,
                         deleteClick = {
                             deleteDevice(device)
                             expanded = false


### PR DESCRIPTION
This is a small visual improvement to quickly see which device and app is currently selected when looking at the dropdown menu. When running multiple emulators or app variants it is sometimes hard to see which one is the one that is already selected, so I added a background color to make the selected one stand out a bit more.

<img width="281" height="310" alt="image1" src="https://github.com/user-attachments/assets/6056bfce-c98f-4589-80e7-a76e00186b83" />
