### PR TITLE
Fix mock edition window crashing

### DIFF
--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/network/mock/edition/view/NetworkEditionWindow.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/network/mock/edition/view/NetworkEditionWindow.kt
@@ -406,11 +406,13 @@ fun MockEditorScreen(
                         if(isEditSelected) {
                             FloconTextField(
                                 value = bodyResponse.body,
-                                minLines = 10,
                                 onValueChange = { newValue ->
                                     mock = mock.copy(bodyResponse = bodyResponse.copy(body = newValue))
                                 },
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(400.dp),
+                                singleLine = false,
                                 containerColor = FloconTheme.colorPalette.primary
                             )
                         } else {


### PR DESCRIPTION
When pasting a large string into the mock edit text field, Compose throws an exception because it can't measure the view correctly anymore. To fix this we need to give the text field a fixed height. This also aligns the height nicely with the validation tabs height.

Closes https://github.com/openflocon/Flocon/issues/525