### PR TITLE
Ignore xcuserdata directory in iOS project

### DIFF
--- a/FloconAndroid/.gitignore
+++ b/FloconAndroid/.gitignore
@@ -20,3 +20,6 @@ local.properties
 # Kotlin Multiplatform
 .kotlin/
 kotlin-js-store/
+
+# iOS
+xcuserdata/


### PR DESCRIPTION
There are some user specific files which get generated for the iOS app. They should be ignored according to [this gitignore](https://github.com/android/kotlin-multiplatform-samples/blob/main/.gitignore), otherwise every contributor will commit their files.