### PR TITLE
Several Deeplink improvements

### DIFF
--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/DeepLinkViewModel.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/DeepLinkViewModel.kt
@@ -78,7 +78,7 @@ class DeepLinkViewModel(
 
     fun setVariable(name: String, value: String) {
         variableValues.update { current ->
-            if(value.isNotEmpty()) {
+            if (value.isNotEmpty()) {
                 current + (name to value)
             } else {
                 current - name

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/DeepLinkViewModel.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/DeepLinkViewModel.kt
@@ -46,22 +46,29 @@ class DeepLinkViewModel(
             deepLinks = mapToUi(
                 history = history,
                 deepLinks = deepLinks.deeplinks,
+                variables = deepLinks.variables,
                 variableValues = variablesValues
             ),
             variables = deepLinks.variables.map { variable ->
                 DeeplinkVariableViewState(
                     name = variable.name,
                     description = variable.description,
-                    value = variablesValues.getOrDefault(
-                        variable.name,
-                        ""
-                    ),
-                    mode = when (val m = variable.mode) {
+                    value = when(val mode = variable.mode) {
+                        is DeeplinkVariableDomainModel.Mode.AutoComplete -> variablesValues.getOrDefault(
+                            key = variable.name,
+                            defaultValue = mode.suggestions.firstOrNull() ?: ""
+                        )
+                        is DeeplinkVariableDomainModel.Mode.Input -> variablesValues.getOrDefault(
+                            key = variable.name,
+                            defaultValue = ""
+                        )
+                    },
+                    mode = when (val mode = variable.mode) {
                         DeeplinkVariableDomainModel.Mode.Input ->
                             DeeplinkVariableViewState.Mode.Input
 
                         is DeeplinkVariableDomainModel.Mode.AutoComplete ->
-                            DeeplinkVariableViewState.Mode.AutoComplete(m.suggestions)
+                            DeeplinkVariableViewState.Mode.AutoComplete(mode.suggestions)
                     }
                 )
             }
@@ -70,7 +77,13 @@ class DeepLinkViewModel(
         .stateInWhileSubscribed(DeeplinkScreenState(emptyList(), emptyList()))
 
     fun setVariable(name: String, value: String) {
-        variableValues.update { current -> current + (name to value) }
+        variableValues.update { current ->
+            if(value.isNotEmpty()) {
+                current + (name to value)
+            } else {
+                current - name
+            }
+        }
     }
 
     fun removeFromHistory(viewState: DeeplinkViewState) {

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/mapper/Mapper.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/mapper/Mapper.kt
@@ -1,6 +1,7 @@
 package io.github.openflocon.flocondesktop.features.deeplinks.mapper
 
 import io.github.openflocon.domain.deeplink.models.DeeplinkDomainModel
+import io.github.openflocon.domain.deeplink.models.DeeplinkVariableDomainModel
 import io.github.openflocon.flocondesktop.features.deeplinks.model.DeeplinkPart
 import io.github.openflocon.flocondesktop.features.deeplinks.model.DeeplinkViewState
 
@@ -12,17 +13,26 @@ data class DeeplinkItem(
 internal fun mapToUi(
     history: List<DeeplinkDomainModel>,
     deepLinks: List<DeeplinkDomainModel>,
+    variables: List<DeeplinkVariableDomainModel>,
     variableValues: Map<String, String>
 ): List<DeeplinkViewState> = buildList {
     addAll(history.map { DeeplinkItem(model = it, isHistory = true) })
     addAll(deepLinks.map { DeeplinkItem(model = it, isHistory = false) })
 }
     .distinctBy { it.model.link }
-    .map { mapToUi(deepLink = it.model, isHistory = it.isHistory, variableValues = variableValues) }
+    .map {
+        mapToUi(
+            deepLink = it.model,
+            isHistory = it.isHistory,
+            variables = variables,
+            variableValues = variableValues
+        )
+    }
 
 internal fun mapToUi(
     deepLink: DeeplinkDomainModel,
     isHistory: Boolean,
+    variables: List<DeeplinkVariableDomainModel>,
     variableValues: Map<String, String>
 ): DeeplinkViewState = DeeplinkViewState(
     label = deepLink.label,
@@ -35,6 +45,7 @@ internal fun mapToUi(
         parseDeeplinkString(
             input = deepLink.link,
             deepLink = deepLink,
+            variables = variables,
             variableValues = variableValues
         )
     }
@@ -43,6 +54,7 @@ internal fun mapToUi(
 internal fun parseDeeplinkString(
     input: String,
     deepLink: DeeplinkDomainModel,
+    variables: List<DeeplinkVariableDomainModel>,
     variableValues: Map<String, String>
 ): List<DeeplinkPart> {
     val regex = "\\[([^\\[\\]]*)\\]".toRegex() // Regex pour trouver [quelquechose]
@@ -73,7 +85,9 @@ internal fun parseDeeplinkString(
                     )
 
                     is DeeplinkDomainModel.Parameter.Variable -> DeeplinkPart.Variable(
-                        value = variableValues[parameter.variableName] ?: "{${parameter.variableName}}"
+                        value = variableValues[parameter.variableName]
+                            ?: variables.firstSuggestionOf(parameter.variableName)
+                            ?: "{${parameter.variableName}}"
                     )
                 }
             )
@@ -92,3 +106,10 @@ internal fun parseDeeplinkString(
 
     return result
 }
+
+private fun List<DeeplinkVariableDomainModel>.firstSuggestionOf(variableName: String): String? =
+    firstOrNull { it.name == variableName }
+        ?.mode
+        ?.let { it as? DeeplinkVariableDomainModel.Mode.AutoComplete }
+        ?.suggestions
+        ?.firstOrNull()

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/view/DeeplinkItemView.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/view/DeeplinkItemView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -72,7 +73,7 @@ fun DeeplinkItemView(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Row(
+            FlowRow(
                     modifier =
                             Modifier.weight(1f)
                                     .clip(FloconTheme.shapes.medium)
@@ -81,7 +82,7 @@ fun DeeplinkItemView(
                                             else FloconTheme.colorPalette.surface
                                     )
                                     .padding(horizontal = 12.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                    verticalArrangement = Arrangement.Center,
             ) {
                 item.parts.fastForEach { part ->
                     TextFieldPart(
@@ -172,7 +173,9 @@ private fun TextFieldPart(
                                     text = item,
                                     style = FloconTheme.typography.bodySmall,
                                     modifier =
-                                            Modifier.clickable {
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .clickable {
                                                         value = item
                                                         isExpanded = false
                                                     }

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/view/DeeplinkScreen.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/view/DeeplinkScreen.kt
@@ -96,7 +96,7 @@ private fun DeeplinkScreen(
                     .fillMaxWidth()
             ) {
                 // Left: Variables
-                DeeplinkPanel(
+                DeeplinkScrollablePanel(
                     title = "Variables",
                     modifier = Modifier
                         .weight(0.3f)
@@ -104,11 +104,12 @@ private fun DeeplinkScreen(
                         .clip(FloconTheme.shapes.medium)
                         .background(FloconTheme.colorPalette.primary),
                 ) {
-                    DeeplinkVariablesPanelView(
-                        variables = state.variables,
-                        onVariableChanged = setVariable,
-                        modifier = Modifier.fillMaxWidth().padding(8.dp),
-                    )
+                    items(state.variables) { item ->
+                        DeeplinkVariableChip(
+                            variable = item,
+                            onValueChange = { setVariable(item.name, it) },
+                        )
+                    }
                 }
 
                 // Right: Deeplinks (non-history)

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/view/DeeplinkVariableChip.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/view/DeeplinkVariableChip.kt
@@ -5,13 +5,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -99,11 +95,13 @@ internal fun DeeplinkVariableChip(
                                 Text(
                                     text = suggestion,
                                     style = FloconTheme.typography.bodySmall,
-                                    modifier = Modifier.clickable {
-                                        value = suggestion
-                                        onValueChange(suggestion)
-                                        isExpanded = false
-                                    }
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            value = suggestion
+                                            onValueChange(suggestion)
+                                            isExpanded = false
+                                        }
                                         .padding(
                                             vertical = 4.dp,
                                             horizontal = 8.dp
@@ -132,9 +130,7 @@ private fun VariableInputField(
         modifier = modifier.background(
             color = FloconTheme.colorPalette.primary,
             shape = RoundedCornerShape(2.dp),
-        )
-            .padding(horizontal = 4.dp, vertical = 2.dp)
-            .width(IntrinsicSize.Min),
+        ).padding(horizontal = 4.dp, vertical = 2.dp),
     ) {
         Text(
             text = placeholder,
@@ -143,6 +139,7 @@ private fun VariableInputField(
             modifier = Modifier.graphicsLayer { alpha = if (isValueEmpty) 1f else 0f },
         )
         BasicTextField(
+            modifier = Modifier.fillMaxWidth(),
             value = value,
             onValueChange = onValueChange,
             textStyle = FloconTheme.typography.bodySmall.copy(

--- a/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/view/DeeplinkVariablesPanelView.kt
+++ b/FloconDesktop/composeApp/src/commonMain/kotlin/io/github/openflocon/flocondesktop/features/deeplinks/view/DeeplinkVariablesPanelView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -33,32 +34,9 @@ import io.github.openflocon.flocondesktop.features.deeplinks.model.DeeplinkVaria
 import io.github.openflocon.library.designsystem.FloconTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-fun DeeplinkVariablesPanelView(
-    variables: List<DeeplinkVariableViewState>,
-    onVariableChanged: (name: String, value: String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    if (variables.isEmpty()) return
-
-    FlowRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        variables.forEach { variable ->
-            DeeplinkVariableChip(
-                variable = variable,
-                onValueChange = { onVariableChanged(variable.name, it) },
-            )
-        }
-    }
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DeeplinkVariableChip(
+internal fun DeeplinkVariableChip(
     variable: DeeplinkVariableViewState,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -167,7 +145,6 @@ private fun VariableInputField(
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
-            maxLines = 1,
             textStyle = FloconTheme.typography.bodySmall.copy(
                 color = FloconTheme.colorPalette.onSurface,
                 fontWeight = FontWeight.Bold,
@@ -182,36 +159,41 @@ private fun VariableInputField(
 @Preview
 private fun DeeplinkVariablesPanelViewPreview() {
     FloconTheme {
-        DeeplinkVariablesPanelView(
-            modifier =
-                Modifier.background(FloconTheme.colorPalette.primary)
-                    .fillMaxWidth()
-                    .padding(8.dp),
-            variables =
-                listOf(
-                    DeeplinkVariableViewState(
-                        name = "userId",
-                        description = "The user id",
-                        value = "",
-                        mode = DeeplinkVariableViewState.Mode.Input,
-                    ),
-                    DeeplinkVariableViewState(
-                        name = "env",
-                        description = null,
-                        value = "staging",
-                        mode =
-                            DeeplinkVariableViewState.Mode.AutoComplete(
-                                listOf("dev", "staging", "prod")
-                            ),
-                    ),
-                    DeeplinkVariableViewState(
-                        name = "token",
-                        description = null,
-                        value = "",
-                        mode = DeeplinkVariableViewState.Mode.Input,
-                    ),
+        Column(
+            modifier = Modifier.background(FloconTheme.colorPalette.primary)
+                .fillMaxWidth()
+                .padding(8.dp)
+        ) {
+            DeeplinkVariableChip(
+                variable = DeeplinkVariableViewState(
+                    name = "userId",
+                    description = "The user id",
+                    value = "",
+                    mode = DeeplinkVariableViewState.Mode.Input,
                 ),
-            onVariableChanged = { _, _ -> },
-        )
+                onValueChange = {}
+            )
+            DeeplinkVariableChip(
+                variable =  DeeplinkVariableViewState(
+                    name = "env",
+                    description = null,
+                    value = "staging",
+                    mode =
+                        DeeplinkVariableViewState.Mode.AutoComplete(
+                            listOf("dev", "staging", "prod")
+                        ),
+                ),
+                onValueChange = {}
+            )
+            DeeplinkVariableChip(
+                variable = DeeplinkVariableViewState(
+                    name = "token",
+                    description = null,
+                    value = "",
+                    mode = DeeplinkVariableViewState.Mode.Input,
+                ),
+                onValueChange = {}
+            )
+        }
     }
 }


### PR DESCRIPTION
I have been using the deeplink feature recently and found a few issues/inconveniences.
I want to add the following fixes:

- Deleting the value of a variable on the left side should show the placeholder in the deeplink again instead of an empty string. Otherwise the deeplink looks broken.
- Variables on the left side which have auto complete values should use the first value as the default. This is for convenience, because you need to choose a value anyway.
- Very long deeplinks should be shown as multiline instead of being crushed at the end of the line.
- The variable view on the left should be scrollable. It was also changed from a FlowRow to a LazyColumn, because it is fast to read when each variable has its own line
- The values of the variables on the left should be multiline for long values
- The auto complete values in the dropdown menu should use the full width to be easily selectable